### PR TITLE
Update DF rev to b4dbb6ac4 (skip non-partition files fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ arrow = "57.0.0"
 arrow-schema = "57.0.0"
 async-trait = "0.1.89"
 dashmap = "6"
-datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
-datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "16e0a5c0" }
+datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
+datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "b4dbb6ac4" }
 futures = "0.3"
 itertools = "0.14"
 log = "0.4"


### PR DESCRIPTION
Update arrow-datafusion to branch-52 HEAD which includes PR #51 (skip files outside partition structure in hive-partitioned listing tables).