### PR TITLE
Update DataFusion rev to 05a6c45 (skip non-join plan rebuild)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ arrow = "57.0.0"
 arrow-schema = "57.0.0"
 async-trait = "0.1.89"
 dashmap = "6"
-datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
-datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "7768d24" }
+datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
 futures = "0.3"
 itertools = "0.14"
 log = "0.4"


### PR DESCRIPTION
## Summary

Bumps the DataFusion rev from \`7768d24\` to \`05a6c45\`, picking up upstream DF #21947 (\`massive-com/arrow-datafusion@05a6c45\`):

> Skip unnecessary plan rebuild in adjust_input_keys_ordering for non-join plans

\`EnforceDistribution::adjust_input_keys_ordering\` no longer returns \`Transformed::yes\` for non-join/non-aggregate plans with no key requirements, eliminating an unnecessary tree rebuild per pass.

## Why

For atlas, this directly cuts physical-optimizer time on plans containing OneOf candidates. \`OneOfExec.children()\` already exposes only the best candidate to the tree walker, but every \`adjust_input_keys_ordering\` call previously rebuilt the entire plan tree regardless. With this fix, non-join plans short-circuit early.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo test\` passes (25 unit + 1 integration test)
- [ ] Wire into atlas; rerun staging tickers SLT