### PR TITLE
[branch-52] Bump DataFusion rev to f62e79d (skip ensure_distribution rebuild)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ arrow = "57.0.0"
 arrow-schema = "57.0.0"
 async-trait = "0.1.89"
 dashmap = "6"
-datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
-datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "05a6c45" }
+datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
+datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "f62e79d" }
 futures = "0.3"
 itertools = "0.14"
 log = "0.4"


### PR DESCRIPTION
## Summary

Bump DataFusion rev `05a6c45` → `f62e79d` to pick up [massive-com/arrow-datafusion#57](https://github.com/massive-com/arrow-datafusion/pull/57), the cherry-pick of upstream [apache/datafusion#22521](https://github.com/apache/datafusion/pull/22521).

The upstream change makes `ensure_distribution` route through `with_new_children_if_necessary`, which short-circuits via `Arc::ptr_eq` when no child plan was actually replaced. Saves the (often expensive) `with_new_children` rebuild on point-query plan shapes where no redistribution is needed.

## Why MV needs to move in lockstep

Atlas pins both the MV crate AND DF separately:
- `datafusion-materialized-views = { rev = "906d9cf" }` ← this PR will produce a new rev
- `datafusion = { rev = "..." }` ← atlas will bump to `f62e79d` once this lands

If the two crates pin different DF revs, cargo resolves them as two separate DF copies in the workspace, which breaks atlas's MV/DF boundary (types don't unify). So MV has to land first.

## Tests

`cargo test` — 25/25 unit + 1/1 integration + 4 ignored doctests pass against the new rev.