### PR TITLE
[X-2935] Bump arrow-datafusion rev to 641f176

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ arrow = "58.0.0"
 arrow-schema = "58.0.0"
 async-trait = "0.1.89"
 dashmap = "6"
-datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
-datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "bb55984b9801167ce381f2b9689b938cf11bab1c" }
+datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
 futures = "0.3"
 itertools = "0.14"
 log = "0.4"


### PR DESCRIPTION
## Summary

Bump pinned arrow-datafusion rev from \`bb55984b9\` to \`641f1767ed\` to pick up the X-2935 PhysicalExtensionCodec breaking change (massive-com/arrow-datafusion#60).

## Affects

- **MV**: pure dependency bump. MV doesn't implement \`PhysicalExtensionCodec\` directly, so the trait signature change has no source impact here.
- **Wire format**: unchanged.
- **Staging / prod blast radius**: none until the atlas PR pins to this MV SHA.

## Test

- Remote CI build/test.