### PR TITLE
[X-2935] Bump arrow-datafusion rev to eccc612

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ arrow = "58.0.0"
 arrow-schema = "58.0.0"
 async-trait = "0.1.89"
 dashmap = "6"
-datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
-datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "641f1767ed505391cb0df9f69e56a54214918888" }
+datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
 futures = "0.3"
 itertools = "0.14"
 log = "0.4"


### PR DESCRIPTION
## Summary

Bump pinned arrow-datafusion rev to \`eccc61281\` to pick up the dedup with_new_children fix (massive-com/arrow-datafusion#61).

## Affects

- **MV**: pure dependency bump.
- **Wire format**: unchanged.
- **Staging / prod blast radius**: none until the atlas PR pins to this MV SHA.

## Test

- Remote CI build/test.