### PR TITLE
[X-2935] Bump arrow-datafusion rev to 3e6bcf2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ arrow = "58.0.0"
 arrow-schema = "58.0.0"
 async-trait = "0.1.89"
 dashmap = "6"
-datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
-datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "eccc61281e0154609a68697cedf16a64961e6b83" }
+datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
+datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3e6bcf2045801d4bd178b18497be4644617ed00a" }
 futures = "0.3"
 itertools = "0.14"
 log = "0.4"


### PR DESCRIPTION
Picks up massive-com/arrow-datafusion#62, which preserves nested `DynamicFilterPhysicalExpr` wrappers through `serialize_physical_expr_with_converter`'s snapshot walk. Required so atlas can bump to a DF rev that doesn't fold `BinaryExpr(AND, static_WHERE, dyn_filter)` to a static literal on the wire.

## Affects

- MV branch-53 -> DF rev `3e6bcf2045801d4bd178b18497be4644617ed00a`
- Atlas will pick this up in the same bump that moves the DF rev forward

## Validation

DF-side tests verified in apache/datafusion#62: 5/5 `dynamic_filter*` proto roundtrip tests pass, including the new `dynamic_filter_nested_in_binary_expr_survives_proto_roundtrip` regression.