### PR TITLE
Update DataFusion branch-54 pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ arrow = "58.3.0"
 arrow-schema = "58.3.0"
 async-trait = "0.1.89"
 dashmap = "6"
-datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
-datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "3821cb9eb5e2d524c4d7595c649d54fd06605841" }
+datafusion = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-common = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-functions = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-functions-aggregate = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-optimizer = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-physical-expr = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-physical-plan = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
+datafusion-sql = { git = "https://github.com/massive-com/arrow-datafusion", rev = "6363fbeb2a593e78fb6d73ad07ddba13c0406949" }
 futures = "0.3"
 itertools = "0.14"
 log = "0.4"

--- a/src/materialized/dependencies.rs
+++ b/src/materialized/dependencies.rs
@@ -504,11 +504,7 @@ fn pushdown_projection_inexact(plan: LogicalPlan, indices: &HashSet<usize>) -> R
             )
             .map(LogicalPlan::Filter)
         }
-        LogicalPlan::Window(Window {
-            input,
-            window_expr: _,
-            ..
-        }) => {
+        LogicalPlan::Window(Window { input, .. }) => {
             // Window nodes take their input and append window expressions to the end.
             // If our projection doesn't include window expressions, we can just turn
             // the window into a regular projection.

--- a/src/materialized/file_metadata.rs
+++ b/src/materialized/file_metadata.rs
@@ -268,17 +268,15 @@ impl FileMetadataExec {
             return None;
         }
 
-        let (column, literal) = if let Some(left_column) =
-            binary_expr.left().as_ref().downcast_ref::<Column>()
-        {
-            let right_literal = binary_expr.right().as_ref().downcast_ref::<Literal>()?;
-            (left_column, right_literal)
-        } else if let Some(right_column) = binary_expr.right().as_ref().downcast_ref::<Column>() {
-            let left_literal = binary_expr.left().as_ref().downcast_ref::<Literal>()?;
-            (right_column, left_literal)
-        } else {
-            return None;
-        };
+        let (column, literal) =
+            if let Some(left_column) = binary_expr.left().as_ref().downcast_ref::<Column>() {
+                let right_literal = binary_expr.right().as_ref().downcast_ref::<Literal>()?;
+                (left_column, right_literal)
+            } else {
+                let right_column = binary_expr.right().as_ref().downcast_ref::<Column>()?;
+                let left_literal = binary_expr.left().as_ref().downcast_ref::<Literal>()?;
+                (right_column, left_literal)
+            };
 
         if column.index() != column_idx {
             return None;

--- a/tests/materialized_listing_table.rs
+++ b/tests/materialized_listing_table.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{any::Any, borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use arrow::{array::StringArray, compute::concat_batches, util::pretty};
@@ -393,7 +393,7 @@ async fn refresh_materialized_listing_table(
     let table = ctx.table_provider(table_name.clone()).await?;
 
     for target in &targets {
-        refresh_mv_target(ctx, table.as_any().downcast_ref().unwrap(), target).await?;
+        refresh_mv_target(ctx, table.downcast_ref().unwrap(), target).await?;
     }
 
     if ctx
@@ -486,10 +486,6 @@ impl MaterializedListingTable {
 
 #[async_trait::async_trait]
 impl TableProvider for MaterializedListingTable {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)
     }


### PR DESCRIPTION
Bumps the DataFusion branch-54 pin to `6363fbe` to pick up [`massive-com/arrow-datafusion#67`](https://github.com/massive-com/arrow-datafusion/pull/67) (Support UDTFs in information_schema.routines / SHOW FUNCTIONS). Needed so atlas can bump its own DF pin to the same commit; upstream equivalent is [`apache/datafusion#23438`](https://github.com/apache/datafusion/pull/23438).