### PR TITLE
Updatable View Matcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ itertools = "0.14"
 log = "0.4"
 object_store = "0.13.1"
 ordered-float = "5.0.0"
+parking_lot = "0.12"
 
 [dev-dependencies]
 anyhow = "1.0.95"

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -43,6 +43,7 @@ to push down relevant information such as projections, sorts, and filters into t
 
 */
 
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::{collections::HashSet, sync::Arc};
 
@@ -153,16 +154,47 @@ impl<'a> CostContext<'a> {
 
 /// A cost function. Used to evaluate the best physical plan among multiple equivalent choices.
 pub type CostFn = Arc<dyn for<'a> Fn(CostContext<'a>) -> Vec<f64> + Send + Sync>;
-
+/// A materialized view that is a candidate for query rewriting: the analyzed
+/// [`SpjNormalForm`] of its defining query paired with its table provider.
+#[derive(Debug, Clone)]
+pub struct ViewMatcherTable {
+    /// The SPJ normal form of the materialized view's defining query.
+    pub spj_normal_form: Arc<SpjNormalForm>,
+    /// The materialized view's table provider.
+    pub table: Arc<dyn TableProvider>,
+}
 /// A logical optimizer that generates candidate logical plans in the form of [`OneOf`] nodes.
 #[derive(Debug)]
 pub struct ViewMatcher {
-    mv_plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)>,
+    mv_plans: RwLock<Arc<HashMap<TableReference, ViewMatcherTable>>>,
 }
 
 impl ViewMatcher {
     /// Loads table information and processes all views, returning a new optimizer rule.
     pub async fn try_new_from_state(session_state: &SessionState) -> Result<Self> {
+        let mv_plans = Self::build_mv_plans(session_state).await?;
+        Ok(ViewMatcher {
+            mv_plans: RwLock::new(Arc::new(mv_plans)),
+        })
+    }
+
+    /// Re-scans the catalogs in `session_state` and atomically replaces the set of
+    /// materialized-view candidates used for query rewriting.
+    ///
+    /// Call this after tables or materialized views are registered or deregistered so
+    /// rewrites reflect the current catalog contents. In-flight rewrites keep the
+    /// snapshot they started with.
+    pub async fn update_candidates(&self, session_state: &SessionState) -> Result<()> {
+        let mv_plans = Self::build_mv_plans(session_state).await?;
+        *self.mv_plans.write() = Arc::new(mv_plans);
+        Ok(())
+    }
+
+    /// Scans all catalogs for materialized views enabled for query rewriting and
+    /// computes their SPJ normal forms.
+    async fn build_mv_plans(
+        session_state: &SessionState,
+    ) -> Result<HashMap<TableReference, ViewMatcherTable>> {
         let mut mv_plans: HashMap<TableReference, _> = HashMap::default();
         for (resolved_table_ref, table) in
             super::util::list_tables(session_state.catalog_list().as_ref()).await?
@@ -187,17 +219,22 @@ impl ViewMatcher {
                     log::trace!("can't support view matching for {resolved_table_ref}: {e}")
                 }
                 Ok(normal_form) => {
-                    mv_plans.insert(resolved_table_ref.clone().into(), (table, normal_form));
+                    mv_plans.insert(
+                        resolved_table_ref.clone().into(),
+                        ViewMatcherTable {
+                            spj_normal_form: Arc::new(normal_form),
+                            table,
+                        },
+                    );
                 }
             }
         }
-
-        Ok(ViewMatcher { mv_plans })
+        Ok(mv_plans)
     }
 
-    /// Returns the materialized views and their corresponding normal forms.
-    pub fn mv_plans(&self) -> &HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)> {
-        &self.mv_plans
+    /// Returns a snapshot of the materialized views and their corresponding normal forms.
+    pub fn mv_plans(&self) -> Arc<HashMap<TableReference, ViewMatcherTable>> {
+        self.mv_plans.read().clone()
     }
 
     /// Test-only constructor that skips the full `try_new_from_state` catalog
@@ -208,9 +245,11 @@ impl ViewMatcher {
     /// to assert the upstream filter.
     #[cfg(test)]
     pub(crate) fn from_mv_plans_for_test(
-        mv_plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)>,
+        mv_plans: HashMap<TableReference, ViewMatcherTable>,
     ) -> Self {
-        Self { mv_plans }
+        Self {
+            mv_plans: RwLock::new(Arc::new(mv_plans)),
+        }
     }
 
     /// Returns materialized views that potentially reference the given table.
@@ -225,24 +264,23 @@ impl ViewMatcher {
     ///
     /// # Returns
     ///
-    /// A vector of tuples containing:
-    /// - The materialized view's table reference
-    /// - The materialized view's table provider
-    /// - The materialized view's SPJ normal form
+    /// A vector of tuples containing the materialized view's table reference and its
+    /// [`ViewMatcherTable`] (table provider + SPJ normal form).
     pub fn get_potential_mv_candidates_for_table(
         &self,
         table_reference: &TableReference,
-    ) -> Vec<(TableReference, Arc<dyn TableProvider>, &SpjNormalForm)> {
-        self.mv_plans
+    ) -> Vec<(TableReference, ViewMatcherTable)> {
+        let plans = self.mv_plans.read().clone();
+        plans
             .iter()
-            .filter_map(|(mv_table_ref, (mv_provider, mv_normal_form))| {
+            .filter_map(|(mv_table_ref, table)| {
                 // Check if this MV references the target table
-                if mv_normal_form.referenced_tables().contains(table_reference) {
-                    Some((
-                        mv_table_ref.clone(),
-                        Arc::clone(mv_provider),
-                        mv_normal_form,
-                    ))
+                if table
+                    .spj_normal_form
+                    .referenced_tables()
+                    .contains(table_reference)
+                {
+                    Some((mv_table_ref.clone(), table.clone()))
                 } else {
                     None
                 }
@@ -268,7 +306,9 @@ impl OptimizerRule for ViewMatcher {
             return Ok(Transformed::no(plan));
         }
 
-        plan.rewrite(&mut ViewMatchingRewriter { parent: self })
+        plan.rewrite(&mut ViewMatchingRewriter {
+            mv_plans: self.mv_plans(),
+        })
     }
 
     fn supports_rewrite(&self) -> bool {
@@ -281,11 +321,11 @@ impl OptimizerRule for ViewMatcher {
 }
 
 /// A logical plan rewriter that looks for opportunities for substitution.
-struct ViewMatchingRewriter<'a> {
-    parent: &'a ViewMatcher,
+struct ViewMatchingRewriter {
+    mv_plans: Arc<HashMap<TableReference, ViewMatcherTable>>,
 }
 
-impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
+impl TreeNodeRewriter for ViewMatchingRewriter {
     type Node = LogicalPlan;
 
     fn f_down(&mut self, node: Self::Node) -> Result<Transformed<Self::Node>> {
@@ -325,12 +365,15 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
         // predicate-pruned). Erasing the readiness at this layer would silently
         // promote every default (`Unknown`) provider to `Ready`.
         let candidates: Vec<(LogicalPlan, TableReference, RewriteReadiness)> = self
-            .parent
             .mv_plans
             .iter()
-            .filter_map(|(table_ref, (table, plan))| {
+            .filter_map(|(table_ref, table)| {
                 // Only attempt rewrite if the view references our table in the first place
-                if !plan.referenced_tables().contains(&table_reference) {
+                if !table
+                    .spj_normal_form
+                    .referenced_tables()
+                    .contains(&table_reference)
+                {
                     return None;
                 }
                 // Drop `NotReady` MVs upfront. `Ready` and `Unknown` both pass
@@ -343,7 +386,7 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                 // to `Unknown` so catalog issues stay debuggable, then treat the
                 // MV as Unknown (the pre-existing "include as candidate, cost
                 // function decides" default) so the rewrite path keeps functioning.
-                let readiness = match cast_to_materialized(table.as_ref()) {
+                let readiness = match cast_to_materialized(table.table.as_ref()) {
                     Ok(Some(mv)) => mv.rewrite_readiness(),
                     Ok(None) => RewriteReadiness::Unknown,
                     Err(e) => {
@@ -359,9 +402,9 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                     return None;
                 }
                 form.rewrite_from(
-                    plan,
+                    &table.spj_normal_form,
                     table_ref.clone(),
-                    provider_as_source(Arc::clone(table)),
+                    provider_as_source(Arc::clone(&table.table)),
                 )
                 .transpose()
                 .map(|res| res.map(|lp| (lp, table_ref.clone(), readiness)))
@@ -1469,8 +1512,7 @@ mod tests_view_matcher_readiness_filter {
     /// candidates survived by their `TableReference`.
     fn build_matcher_with_three_readiness_states(source_table: &str) -> ViewMatcher {
         crate::materialized::register_materialized::<MockMv>();
-        let mut plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)> =
-            HashMap::new();
+        let mut plans: HashMap<TableReference, ViewMatcherTable> = HashMap::new();
         for (name, readiness) in [
             ("mv_ready", RewriteReadiness::Ready),
             ("mv_not_ready", RewriteReadiness::NotReady),
@@ -1480,7 +1522,10 @@ mod tests_view_matcher_readiness_filter {
             let form = SpjNormalForm::new(&mv.query).expect("MV LP is a valid SPJ");
             plans.insert(
                 TableReference::bare(name),
-                (mv.clone() as Arc<dyn TableProvider>, form),
+                ViewMatcherTable {
+                    spj_normal_form: Arc::new(form),
+                    table: mv.clone() as Arc<dyn TableProvider>,
+                },
             );
         }
         ViewMatcher::from_mv_plans_for_test(plans)
@@ -1497,7 +1542,9 @@ mod tests_view_matcher_readiness_filter {
             .expect("build query LP");
 
         query
-            .rewrite(&mut ViewMatchingRewriter { parent: matcher })
+            .rewrite(&mut ViewMatchingRewriter {
+                mv_plans: matcher.mv_plans(),
+            })
             .expect("rewrite scan")
             .data
     }
@@ -1565,13 +1612,15 @@ mod tests_view_matcher_readiness_filter {
         // return the original scan unchanged, not wrap it in a candidate-less
         // OneOf.
         crate::materialized::register_materialized::<MockMv>();
-        let mut plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)> =
-            HashMap::new();
+        let mut plans: HashMap<TableReference, ViewMatcherTable> = HashMap::new();
         let mv = MockMv::new("target_t", RewriteReadiness::NotReady);
         let form = SpjNormalForm::new(&mv.query).expect("valid SPJ");
         plans.insert(
             TableReference::bare("mv_not_ready_only"),
-            (mv as Arc<dyn TableProvider>, form),
+            ViewMatcherTable {
+                spj_normal_form: Arc::new(form),
+                table: mv as Arc<dyn TableProvider>,
+            },
         );
         let matcher = ViewMatcher::from_mv_plans_for_test(plans);
 
@@ -1699,11 +1748,13 @@ mod tests_view_matcher_readiness_filter {
         crate::materialized::register_materialized::<MockMv>();
         let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
         let form = SpjNormalForm::new(&mv.query).expect("valid SPJ");
-        let mut plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)> =
-            HashMap::new();
+        let mut plans: HashMap<TableReference, ViewMatcherTable> = HashMap::new();
         plans.insert(
             TableReference::bare("mv_cold_lazy"),
-            (Arc::clone(&mv) as Arc<dyn TableProvider>, form),
+            ViewMatcherTable {
+                spj_normal_form: Arc::new(form),
+                table: Arc::clone(&mv) as Arc<dyn TableProvider>,
+            },
         );
         let matcher = ViewMatcher::from_mv_plans_for_test(plans);
 

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -58,7 +58,7 @@ use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion, TreeNodeRewriter};
-use datafusion_common::{DataFusionError, Result, TableReference};
+use datafusion_common::{DataFusionError, ResolvedTableReference, Result, TableReference};
 use datafusion_expr::{Extension, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore};
 use datafusion_optimizer::OptimizerRule;
 use datafusion_physical_expr::OrderingRequirements;
@@ -164,6 +164,11 @@ pub struct ViewMatcherTable {
     pub table: Arc<dyn TableProvider>,
 }
 /// A logical optimizer that generates candidate logical plans in the form of [`OneOf`] nodes.
+///
+/// The candidate set can be maintained incrementally as the catalog changes:
+/// [`refresh_candidate`](Self::refresh_candidate) re-analyzes a single table,
+/// [`invalidate_candidate`](Self::invalidate_candidate) immediately removes one, and
+/// [`update_candidates`](Self::update_candidates) rescans everything.
 #[derive(Debug)]
 pub struct ViewMatcher {
     /// A COW like structure. Each time OptimizerRule::rewrite is called. This will be read and cloned.
@@ -263,6 +268,11 @@ impl ViewMatcher {
     /// serialized, so the candidate set always converges to the catalog state seen by
     /// the last completed call.
     ///
+    /// Fails closed: if the refresh errors (catalog lookup or analysis failure), the
+    /// table's candidate is removed so a possibly-stale entry is never used for
+    /// rewriting, and the error is returned. The table becomes a candidate again once
+    /// a later refresh succeeds for it.
+    ///
     /// Prefer this over [`update_candidates`](Self::update_candidates) when a single
     /// table changed: it analyzes only that table instead of re-scanning every catalog.
     pub async fn refresh_candidate(
@@ -277,6 +287,24 @@ impl ViewMatcher {
         let resolved = table_ref
             .into()
             .resolve(&catalog_conf.default_catalog, &catalog_conf.default_schema);
+
+        match self.refresh_candidate_inner(session_state, &resolved).await {
+            Ok(is_candidate) => Ok(is_candidate),
+            Err(e) => {
+                // Never leave a possibly-stale candidate behind on failure.
+                self.remove_entry(&TableReference::from(resolved));
+                Err(e)
+            }
+        }
+    }
+
+    /// The fallible part of [`refresh_candidate`](Self::refresh_candidate); the caller
+    /// must hold `update_lock` and handle errors by removing the table's candidate.
+    async fn refresh_candidate_inner(
+        &self,
+        session_state: &SessionState,
+        resolved: &ResolvedTableReference,
+    ) -> Result<bool> {
         let table_ref = TableReference::from(resolved.clone());
 
         // Look the provider up from the catalog rather than trusting the caller,
@@ -292,14 +320,7 @@ impl ViewMatcher {
 
         let candidate = match table {
             None => None,
-            Some(table) => match Self::build_candidate(session_state, &table_ref, table) {
-                Ok(candidate) => candidate,
-                Err(e) => {
-                    // Never leave a stale candidate behind on analysis failure.
-                    self.remove_entry(&table_ref);
-                    return Err(e);
-                }
-            },
+            Some(table) => Self::build_candidate(session_state, &table_ref, table)?,
         };
 
         let Some(candidate) = candidate else {
@@ -313,6 +334,29 @@ impl ViewMatcher {
         mv_plans.insert(table_ref, candidate);
         *guard = Arc::new(mv_plans);
         Ok(true)
+    }
+
+    /// Immediately removes the candidate for `table_ref` from the active set, so query
+    /// rewrites stop using it. The table is re-added by the next
+    /// [`refresh_candidate`](Self::refresh_candidate) or
+    /// [`update_candidates`](Self::update_candidates) call if it is still a
+    /// materialized view enabled for query rewriting.
+    ///
+    /// `table_ref` is resolved against the session's default catalog and schema, so
+    /// bare, partial, and fully-qualified references all address the same entry.
+    ///
+    /// Returns whether a candidate was removed.
+    pub async fn invalidate_candidate(
+        &self,
+        session_state: &SessionState,
+        table_ref: impl Into<TableReference>,
+    ) -> bool {
+        let _guard = self.update_lock.lock().await;
+        let catalog_conf = &session_state.config_options().catalog;
+        let resolved = table_ref
+            .into()
+            .resolve(&catalog_conf.default_catalog, &catalog_conf.default_schema);
+        self.remove_entry(&TableReference::from(resolved))
     }
 
     /// Removes the candidate for `table_ref`, if present. Returns whether one was removed.
@@ -2550,12 +2594,16 @@ mod tests_physical_time_readiness_refresh {
 
 #[cfg(test)]
 mod tests_incremental_candidates {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use super::*;
     use arrow_schema::{DataType, Field, Schema, SchemaRef};
-    use datafusion::catalog::Session;
+    use datafusion::catalog::{SchemaProvider, Session};
     use datafusion::datasource::empty::EmptyTable;
     use datafusion::datasource::listing::ListingTableUrl;
+    use datafusion::optimizer::AnalyzerRule;
     use datafusion::prelude::SessionContext;
+    use datafusion_common::config::ConfigOptions;
     use datafusion_expr::{Expr, LogicalPlanBuilder, TableType};
 
     use crate::materialized::{register_materialized, ListingTableLike, Materialized};
@@ -2575,8 +2623,12 @@ mod tests_incremental_candidates {
     }
 
     fn mock_mv() -> Arc<dyn TableProvider> {
-        let query = LogicalPlanBuilder::scan("base", provider_as_source(empty_table()), None)
-            .expect("scan base")
+        mock_mv_scanning("base")
+    }
+
+    fn mock_mv_scanning(table_name: &str) -> Arc<dyn TableProvider> {
+        let query = LogicalPlanBuilder::scan(table_name, provider_as_source(empty_table()), None)
+            .expect("scan")
             .build()
             .expect("build query");
         Arc::new(MockMv { query })
@@ -2692,5 +2744,165 @@ mod tests_incremental_candidates {
             .expect("refresh_candidate");
         assert!(!added);
         assert!(matcher.mv_plans().is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalidate_candidate_removes_entry() {
+        register_materialized::<MockMv>();
+
+        let ctx = SessionContext::new();
+        ctx.register_table("mv", mock_mv()).expect("register mv");
+        let state = ctx.state();
+        let matcher = ViewMatcher::try_new_from_state(&state)
+            .await
+            .expect("matcher");
+        assert!(matcher.mv_plans().contains_key(&TableReference::full(
+            "datafusion",
+            "public",
+            "mv"
+        )));
+
+        // A bare reference must address the fully qualified entry.
+        assert!(matcher.invalidate_candidate(&state, "mv").await);
+        assert!(matcher.mv_plans().is_empty());
+
+        // Invalidating an absent candidate is a no-op that must not swap the snapshot.
+        let before = matcher.mv_plans();
+        assert!(!matcher.invalidate_candidate(&state, "mv").await);
+        assert!(Arc::ptr_eq(&before, &matcher.mv_plans()));
+
+        // The table is still registered, so a refresh brings the candidate back.
+        let added = matcher
+            .refresh_candidate(&state, "mv")
+            .await
+            .expect("refresh_candidate");
+        assert!(added);
+        assert_eq!(matcher.mv_plans().len(), 1);
+    }
+
+    /// While active, fails analysis of any plan that scans a table named `poison`.
+    #[derive(Debug)]
+    struct PoisonAnalyzerRule {
+        active: Arc<AtomicBool>,
+    }
+
+    impl AnalyzerRule for PoisonAnalyzerRule {
+        fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+            let poisoned = self.active.load(Ordering::SeqCst)
+                && plan.exists(|plan| {
+                    Ok(matches!(
+                        plan,
+                        LogicalPlan::TableScan(scan) if scan.table_name.table() == "poison"
+                    ))
+                })?;
+            if poisoned {
+                datafusion_common::plan_err!("plan is poisoned")
+            } else {
+                Ok(plan)
+            }
+        }
+
+        fn name(&self) -> &str {
+            "poison_analyzer_rule"
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_candidate_analysis_failure_removes_candidate() {
+        register_materialized::<MockMv>();
+
+        let active = Arc::new(AtomicBool::new(false));
+        let ctx = SessionContext::new();
+        ctx.add_analyzer_rule(Arc::new(PoisonAnalyzerRule {
+            active: Arc::clone(&active),
+        }));
+        ctx.register_table("good_mv", mock_mv())
+            .expect("register good_mv");
+        ctx.register_table("bad_mv", mock_mv_scanning("poison"))
+            .expect("register bad_mv");
+        let state = ctx.state();
+        let matcher = ViewMatcher::try_new_from_state(&state)
+            .await
+            .expect("matcher");
+        let good_ref = TableReference::full("datafusion", "public", "good_mv");
+        let bad_ref = TableReference::full("datafusion", "public", "bad_mv");
+        assert!(matcher.mv_plans().contains_key(&good_ref));
+        assert!(matcher.mv_plans().contains_key(&bad_ref));
+
+        active.store(true, Ordering::SeqCst);
+
+        let result = matcher.refresh_candidate(&state, "bad_mv").await;
+        assert!(result.is_err());
+
+        // Fail closed: only the failing table loses its candidate; others are untouched.
+        let plans = matcher.mv_plans();
+        assert!(!plans.contains_key(&bad_ref));
+        assert!(plans.contains_key(&good_ref));
+        assert_eq!(plans.len(), 1);
+    }
+
+    /// A schema provider whose table lookups can be made to fail on demand.
+    #[derive(Debug)]
+    struct PoisonSchemaProvider {
+        tables: HashMap<String, Arc<dyn TableProvider>>,
+        poisoned: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl SchemaProvider for PoisonSchemaProvider {
+        fn table_names(&self) -> Vec<String> {
+            self.tables.keys().cloned().collect()
+        }
+
+        async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
+            if self.poisoned.load(Ordering::SeqCst) {
+                return datafusion_common::internal_err!("schema provider is poisoned");
+            }
+            Ok(self.tables.get(name).cloned())
+        }
+
+        fn table_exist(&self, name: &str) -> bool {
+            self.tables.contains_key(name)
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_candidate_lookup_failure_removes_candidate() {
+        register_materialized::<MockMv>();
+
+        let poisoned = Arc::new(AtomicBool::new(false));
+        let schema = PoisonSchemaProvider {
+            tables: HashMap::from([("mv".to_string(), mock_mv())]),
+            poisoned: Arc::clone(&poisoned),
+        };
+
+        let ctx = SessionContext::new();
+        ctx.catalog("datafusion")
+            .expect("default catalog")
+            .register_schema("fragile", Arc::new(schema))
+            .expect("register schema");
+        ctx.register_table("good_mv", mock_mv())
+            .expect("register good_mv");
+        let state = ctx.state();
+        let matcher = ViewMatcher::try_new_from_state(&state)
+            .await
+            .expect("matcher");
+        let fragile_ref = TableReference::full("datafusion", "fragile", "mv");
+        let good_ref = TableReference::full("datafusion", "public", "good_mv");
+        assert!(matcher.mv_plans().contains_key(&fragile_ref));
+        assert!(matcher.mv_plans().contains_key(&good_ref));
+
+        poisoned.store(true, Ordering::SeqCst);
+
+        let result = matcher
+            .refresh_candidate(&state, "datafusion.fragile.mv")
+            .await;
+        assert!(result.is_err());
+
+        // Fail closed: only the failing table loses its candidate; others are untouched.
+        let plans = matcher.mv_plans();
+        assert!(!plans.contains_key(&fragile_ref));
+        assert!(plans.contains_key(&good_ref));
+        assert_eq!(plans.len(), 1);
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -169,6 +169,9 @@ pub struct ViewMatcher {
     /// A COW like structure. Each time OptimizerRule::rewrite is called. This will be read and cloned.
     /// Keeping the lock held for as little as possible.
     mv_plans: RwLock<Arc<HashMap<TableReference, ViewMatcherTable>>>,
+    /// Serializes mutations (full rescans and single-table refreshes) so a stale
+    /// analysis can never overwrite the result of a newer catalog change.
+    update_lock: futures::lock::Mutex<()>,
 }
 
 impl ViewMatcher {
@@ -177,6 +180,7 @@ impl ViewMatcher {
         let mv_plans = Self::build_mv_plans(session_state).await?;
         Ok(ViewMatcher {
             mv_plans: RwLock::new(Arc::new(mv_plans)),
+            update_lock: futures::lock::Mutex::new(()),
         })
     }
 
@@ -187,6 +191,7 @@ impl ViewMatcher {
     /// rewrites reflect the current catalog contents. In-flight rewrites keep the
     /// snapshot they started with.
     pub async fn update_candidates(&self, session_state: &SessionState) -> Result<()> {
+        let _guard = self.update_lock.lock().await;
         let mv_plans = Self::build_mv_plans(session_state).await?;
         *self.mv_plans.write() = Arc::new(mv_plans);
         Ok(())
@@ -244,28 +249,65 @@ impl ViewMatcher {
         }
     }
 
-    /// Analyzes `table` and inserts/replaces its candidate entry if it is a materialized
-    /// view enabled for query rewriting. If it is not (or its query has no SPJ normal
-    /// form), any existing entry for `table_ref` is removed instead, so a table whose
-    /// definition changed cannot leave a stale candidate behind. Returns whether the
-    /// table is now a candidate.
+    /// Re-analyzes the table registered under `table_ref` and updates its candidate
+    /// entry to match the current catalog contents: the entry is inserted/replaced if
+    /// the table is a materialized view enabled for query rewriting, and removed if the
+    /// table was dropped, is not a materialized view, or its query has no SPJ normal
+    /// form. Returns whether the table is now a candidate.
+    ///
+    /// `table_ref` is resolved against the session's default catalog and schema, so
+    /// bare, partial, and fully-qualified references all address the same entry.
+    ///
+    /// Call this after a catalog change (register/deregister/replace) completes.
+    /// Refreshes and full [`update_candidates`](Self::update_candidates) rescans are
+    /// serialized, so the candidate set always converges to the catalog state seen by
+    /// the last completed call.
     ///
     /// Prefer this over [`update_candidates`](Self::update_candidates) when a single
     /// table changed: it analyzes only that table instead of re-scanning every catalog.
-    pub fn add_candidate(
+    pub async fn refresh_candidate(
         &self,
         session_state: &SessionState,
-        table_ref: TableReference,
-        table: Arc<dyn TableProvider>,
+        table_ref: impl Into<TableReference>,
     ) -> Result<bool> {
-        // The (potentially expensive) analysis runs before the lock is taken.
-        let Some(candidate) = Self::build_candidate(session_state, &table_ref, table)? else {
-            self.remove_candidate(&table_ref);
+        let _guard = self.update_lock.lock().await;
+
+        // Normalize to the fully-qualified form used by `build_mv_plans`.
+        let catalog_conf = &session_state.config_options().catalog;
+        let resolved = table_ref
+            .into()
+            .resolve(&catalog_conf.default_catalog, &catalog_conf.default_schema);
+        let table_ref = TableReference::from(resolved.clone());
+
+        // Look the provider up from the catalog rather than trusting the caller,
+        // so the entry always reflects what is actually registered.
+        let table = match session_state
+            .catalog_list()
+            .catalog(&resolved.catalog)
+            .and_then(|catalog| catalog.schema(&resolved.schema))
+        {
+            Some(schema) => schema.table(&resolved.table).await?,
+            None => None,
+        };
+
+        let candidate = match table {
+            None => None,
+            Some(table) => match Self::build_candidate(session_state, &table_ref, table) {
+                Ok(candidate) => candidate,
+                Err(e) => {
+                    // Never leave a stale candidate behind on analysis failure.
+                    self.remove_entry(&table_ref);
+                    return Err(e);
+                }
+            },
+        };
+
+        let Some(candidate) = candidate else {
+            self.remove_entry(&table_ref);
             return Ok(false);
         };
 
-        // Clone under the write lock so concurrent add/remove calls cannot lose updates;
-        // readers keep the snapshot they already cloned.
+        // Clone under the write lock; readers keep the snapshot they already cloned.
         let mut guard = self.mv_plans.write();
         let mut mv_plans = (**guard).clone();
         mv_plans.insert(table_ref, candidate);
@@ -274,7 +316,7 @@ impl ViewMatcher {
     }
 
     /// Removes the candidate for `table_ref`, if present. Returns whether one was removed.
-    pub fn remove_candidate(&self, table_ref: &TableReference) -> bool {
+    fn remove_entry(&self, table_ref: &TableReference) -> bool {
         let mut guard = self.mv_plans.write();
         if !guard.contains_key(table_ref) {
             return false;
@@ -302,6 +344,7 @@ impl ViewMatcher {
     ) -> Self {
         Self {
             mv_plans: RwLock::new(Arc::new(mv_plans)),
+            update_lock: futures::lock::Mutex::new(()),
         }
     }
 
@@ -2508,9 +2551,14 @@ mod tests_physical_time_readiness_refresh {
 #[cfg(test)]
 mod tests_incremental_candidates {
     use super::*;
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field, Schema, SchemaRef};
+    use datafusion::catalog::Session;
     use datafusion::datasource::empty::EmptyTable;
+    use datafusion::datasource::listing::ListingTableUrl;
     use datafusion::prelude::SessionContext;
+    use datafusion_expr::{Expr, LogicalPlanBuilder, TableType};
+
+    use crate::materialized::{register_materialized, ListingTableLike, Materialized};
 
     fn empty_table() -> Arc<dyn TableProvider> {
         Arc::new(EmptyTable::new(Arc::new(Schema::new(vec![Field::new(
@@ -2520,8 +2568,83 @@ mod tests_incremental_candidates {
         )]))))
     }
 
+    /// A minimal materialized view for exercising the candidate bookkeeping.
+    #[derive(Debug)]
+    struct MockMv {
+        query: LogicalPlan,
+    }
+
+    fn mock_mv() -> Arc<dyn TableProvider> {
+        let query = LogicalPlanBuilder::scan("base", provider_as_source(empty_table()), None)
+            .expect("scan base")
+            .build()
+            .expect("build query");
+        Arc::new(MockMv { query })
+    }
+
+    #[async_trait]
+    impl TableProvider for MockMv {
+        fn schema(&self) -> SchemaRef {
+            Arc::new(self.query.schema().as_arrow().clone())
+        }
+
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+
+        async fn scan(
+            &self,
+            _state: &dyn Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            unimplemented!()
+        }
+    }
+
+    impl ListingTableLike for MockMv {
+        fn table_paths(&self) -> Vec<ListingTableUrl> {
+            vec![]
+        }
+
+        fn partition_columns(&self) -> Vec<String> {
+            vec![]
+        }
+
+        fn file_ext(&self) -> String {
+            "parquet".to_string()
+        }
+    }
+
+    impl Materialized for MockMv {
+        fn query(&self) -> LogicalPlan {
+            self.query.clone()
+        }
+    }
+
     #[tokio::test]
-    async fn add_candidate_ignores_non_materialized_tables() {
+    async fn refresh_candidate_ignores_non_materialized_tables() {
+        let ctx = SessionContext::new();
+        ctx.register_table("t", empty_table()).expect("register t");
+        let state = ctx.state();
+        let matcher = ViewMatcher::try_new_from_state(&state)
+            .await
+            .expect("empty matcher");
+        let before = matcher.mv_plans();
+
+        let added = matcher
+            .refresh_candidate(&state, "t")
+            .await
+            .expect("refresh_candidate");
+
+        assert!(!added);
+        // A non-candidate table must not swap the snapshot at all.
+        assert!(Arc::ptr_eq(&before, &matcher.mv_plans()));
+    }
+
+    #[tokio::test]
+    async fn refresh_candidate_is_noop_for_unknown_table() {
         let ctx = SessionContext::new();
         let state = ctx.state();
         let matcher = ViewMatcher::try_new_from_state(&state)
@@ -2530,23 +2653,44 @@ mod tests_incremental_candidates {
         let before = matcher.mv_plans();
 
         let added = matcher
-            .add_candidate(&state, TableReference::from("t"), empty_table())
-            .expect("add_candidate");
+            .refresh_candidate(&state, "missing")
+            .await
+            .expect("refresh_candidate");
 
         assert!(!added);
-        // A non-candidate table must not swap the snapshot at all.
         assert!(Arc::ptr_eq(&before, &matcher.mv_plans()));
     }
 
     #[tokio::test]
-    async fn remove_candidate_is_noop_when_absent() {
-        let ctx = SessionContext::new();
-        let matcher = ViewMatcher::try_new_from_state(&ctx.state())
-            .await
-            .expect("empty matcher");
-        let before = matcher.mv_plans();
+    async fn refresh_candidate_normalizes_table_refs() {
+        register_materialized::<MockMv>();
 
-        assert!(!matcher.remove_candidate(&TableReference::from("t")));
-        assert!(Arc::ptr_eq(&before, &matcher.mv_plans()));
+        let ctx = SessionContext::new();
+        ctx.register_table("mv", mock_mv()).expect("register mv");
+        let state = ctx.state();
+        let matcher = ViewMatcher::try_new_from_state(&state)
+            .await
+            .expect("matcher");
+
+        // The full scan stores the candidate under a fully qualified reference.
+        let full_ref = TableReference::full("datafusion", "public", "mv");
+        assert!(matcher.mv_plans().contains_key(&full_ref));
+
+        // A bare reference must address the same entry, not create a second one.
+        let added = matcher
+            .refresh_candidate(&state, "mv")
+            .await
+            .expect("refresh_candidate");
+        assert!(added);
+        assert_eq!(matcher.mv_plans().len(), 1);
+
+        // After deregistration, refreshing under any spelling removes the entry.
+        ctx.deregister_table("mv").expect("deregister mv");
+        let added = matcher
+            .refresh_candidate(&state, "datafusion.public.mv")
+            .await
+            .expect("refresh_candidate");
+        assert!(!added);
+        assert!(matcher.mv_plans().is_empty());
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -199,37 +199,88 @@ impl ViewMatcher {
         for (resolved_table_ref, table) in
             super::util::list_tables(session_state.catalog_list().as_ref()).await?
         {
-            let Some(mv) = cast_to_materialized(table.as_ref())? else {
-                continue;
-            };
-
-            if !mv.config().use_in_query_rewrite {
-                continue;
-            }
-
-            // Analyze the plan to normalize things such as wildcard expressions
-            let analyzed_plan = session_state.analyzer().execute_and_check(
-                mv.query(),
-                session_state.config_options(),
-                |_, _| {},
-            )?;
-
-            match SpjNormalForm::new(&analyzed_plan) {
-                Err(e) => {
-                    log::trace!("can't support view matching for {resolved_table_ref}: {e}")
-                }
-                Ok(normal_form) => {
-                    mv_plans.insert(
-                        resolved_table_ref.clone().into(),
-                        ViewMatcherTable {
-                            spj_normal_form: Arc::new(normal_form),
-                            table,
-                        },
-                    );
-                }
+            let table_ref = TableReference::from(resolved_table_ref);
+            if let Some(candidate) = Self::build_candidate(session_state, &table_ref, table)? {
+                mv_plans.insert(table_ref, candidate);
             }
         }
         Ok(mv_plans)
+    }
+
+    /// Computes the [`ViewMatcherTable`] candidate for one table, or `None` if the table
+    /// is not a materialized view enabled for query rewriting, or its query has no SPJ
+    /// normal form (trace-logged and skipped). Analyzer errors propagate.
+    fn build_candidate(
+        session_state: &SessionState,
+        table_ref: &TableReference,
+        table: Arc<dyn TableProvider>,
+    ) -> Result<Option<ViewMatcherTable>> {
+        let Some(mv) = cast_to_materialized(table.as_ref())? else {
+            return Ok(None);
+        };
+
+        if !mv.config().use_in_query_rewrite {
+            return Ok(None);
+        }
+
+        // Analyze the plan to normalize things such as wildcard expressions
+        let analyzed_plan = session_state.analyzer().execute_and_check(
+            mv.query(),
+            session_state.config_options(),
+            |_, _| {},
+        )?;
+
+        match SpjNormalForm::new(&analyzed_plan) {
+            Err(e) => {
+                log::trace!("can't support view matching for {table_ref}: {e}");
+                Ok(None)
+            }
+            Ok(normal_form) => Ok(Some(ViewMatcherTable {
+                spj_normal_form: Arc::new(normal_form),
+                table,
+            })),
+        }
+    }
+
+    /// Analyzes `table` and inserts/replaces its candidate entry if it is a materialized
+    /// view enabled for query rewriting. If it is not (or its query has no SPJ normal
+    /// form), any existing entry for `table_ref` is removed instead, so a table whose
+    /// definition changed cannot leave a stale candidate behind. Returns whether the
+    /// table is now a candidate.
+    ///
+    /// Prefer this over [`update_candidates`](Self::update_candidates) when a single
+    /// table changed: it analyzes only that table instead of re-scanning every catalog.
+    pub fn add_candidate(
+        &self,
+        session_state: &SessionState,
+        table_ref: TableReference,
+        table: Arc<dyn TableProvider>,
+    ) -> Result<bool> {
+        // The (potentially expensive) analysis runs before the lock is taken.
+        let Some(candidate) = Self::build_candidate(session_state, &table_ref, table)? else {
+            self.remove_candidate(&table_ref);
+            return Ok(false);
+        };
+
+        // Clone under the write lock so concurrent add/remove calls cannot lose updates;
+        // readers keep the snapshot they already cloned.
+        let mut guard = self.mv_plans.write();
+        let mut mv_plans = (**guard).clone();
+        mv_plans.insert(table_ref, candidate);
+        *guard = Arc::new(mv_plans);
+        Ok(true)
+    }
+
+    /// Removes the candidate for `table_ref`, if present. Returns whether one was removed.
+    pub fn remove_candidate(&self, table_ref: &TableReference) -> bool {
+        let mut guard = self.mv_plans.write();
+        if !guard.contains_key(table_ref) {
+            return false;
+        }
+        let mut mv_plans = (**guard).clone();
+        mv_plans.remove(table_ref);
+        *guard = Arc::new(mv_plans);
+        true
     }
 
     /// Returns a snapshot of the materialized views and their corresponding normal forms.
@@ -2449,5 +2500,51 @@ mod tests_physical_time_readiness_refresh {
             readiness_from_plan(&result).is_none(),
             "ReadinessAnnotatedExec must be stripped before plan_extension returns"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests_incremental_candidates {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::datasource::empty::EmptyTable;
+    use datafusion::prelude::SessionContext;
+
+    fn empty_table() -> Arc<dyn TableProvider> {
+        Arc::new(EmptyTable::new(Arc::new(Schema::new(vec![Field::new(
+            "x",
+            DataType::Int32,
+            false,
+        )]))))
+    }
+
+    #[tokio::test]
+    async fn add_candidate_ignores_non_materialized_tables() {
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let matcher = ViewMatcher::try_new_from_state(&state)
+            .await
+            .expect("empty matcher");
+        let before = matcher.mv_plans();
+
+        let added = matcher
+            .add_candidate(&state, TableReference::from("t"), empty_table())
+            .expect("add_candidate");
+
+        assert!(!added);
+        // A non-candidate table must not swap the snapshot at all.
+        assert!(Arc::ptr_eq(&before, &matcher.mv_plans()));
+    }
+
+    #[tokio::test]
+    async fn remove_candidate_is_noop_when_absent() {
+        let ctx = SessionContext::new();
+        let matcher = ViewMatcher::try_new_from_state(&ctx.state())
+            .await
+            .expect("empty matcher");
+        let before = matcher.mv_plans();
+
+        assert!(!matcher.remove_candidate(&TableReference::from("t")));
+        assert!(Arc::ptr_eq(&before, &matcher.mv_plans()));
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -166,6 +166,8 @@ pub struct ViewMatcherTable {
 /// A logical optimizer that generates candidate logical plans in the form of [`OneOf`] nodes.
 #[derive(Debug)]
 pub struct ViewMatcher {
+    /// A COW like structure. Each time OptimizerRule::rewrite is called. This will be read and cloned.
+    /// Keeping the lock held for as little as possible.
     mv_plans: RwLock<Arc<HashMap<TableReference, ViewMatcherTable>>>,
 }
 

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -159,7 +159,7 @@ pub type CostFn = Arc<dyn for<'a> Fn(CostContext<'a>) -> Vec<f64> + Send + Sync>
 #[derive(Debug, Clone)]
 pub struct ViewMatcherTable {
     /// The SPJ normal form of the materialized view's defining query.
-    pub spj_normal_form: Arc<SpjNormalForm>,
+    pub normal_form: Arc<SpjNormalForm>,
     /// The materialized view's table provider.
     pub table: Arc<dyn TableProvider>,
 }
@@ -236,7 +236,7 @@ impl ViewMatcher {
                 Ok(None)
             }
             Ok(normal_form) => Ok(Some(ViewMatcherTable {
-                spj_normal_form: Arc::new(normal_form),
+                normal_form: Arc::new(normal_form),
                 table,
             })),
         }
@@ -327,7 +327,7 @@ impl ViewMatcher {
             .filter_map(|(mv_table_ref, table)| {
                 // Check if this MV references the target table
                 if table
-                    .spj_normal_form
+                    .normal_form
                     .referenced_tables()
                     .contains(table_reference)
                 {
@@ -421,7 +421,7 @@ impl TreeNodeRewriter for ViewMatchingRewriter {
             .filter_map(|(table_ref, table)| {
                 // Only attempt rewrite if the view references our table in the first place
                 if !table
-                    .spj_normal_form
+                    .normal_form
                     .referenced_tables()
                     .contains(&table_reference)
                 {
@@ -453,7 +453,7 @@ impl TreeNodeRewriter for ViewMatchingRewriter {
                     return None;
                 }
                 form.rewrite_from(
-                    &table.spj_normal_form,
+                    &table.normal_form,
                     table_ref.clone(),
                     provider_as_source(Arc::clone(&table.table)),
                 )
@@ -1574,7 +1574,7 @@ mod tests_view_matcher_readiness_filter {
             plans.insert(
                 TableReference::bare(name),
                 ViewMatcherTable {
-                    spj_normal_form: Arc::new(form),
+                    normal_form: Arc::new(form),
                     table: mv.clone() as Arc<dyn TableProvider>,
                 },
             );
@@ -1669,7 +1669,7 @@ mod tests_view_matcher_readiness_filter {
         plans.insert(
             TableReference::bare("mv_not_ready_only"),
             ViewMatcherTable {
-                spj_normal_form: Arc::new(form),
+                normal_form: Arc::new(form),
                 table: mv as Arc<dyn TableProvider>,
             },
         );
@@ -1803,7 +1803,7 @@ mod tests_view_matcher_readiness_filter {
         plans.insert(
             TableReference::bare("mv_cold_lazy"),
             ViewMatcherTable {
-                spj_normal_form: Arc::new(form),
+                normal_form: Arc::new(form),
                 table: Arc::clone(&mv) as Arc<dyn TableProvider>,
             },
         );


### PR DESCRIPTION
Allows the set of view-matching candidates to be updated at runtime, instead of being frozen at `ViewMatcher::try_new_from_state` time.

## Motivation

`ViewMatcher` scanned every catalog once at construction and stored the result in a plain `HashMap` behind `&self`. Any materialized view registered, replaced, or dropped afterwards was invisible to query rewriting until the whole `ViewMatcher` (and therefore the `SessionState` holding it) was rebuilt. Long-lived services that register MVs dynamically need the candidate set to track the catalog.

## What changed

### `ViewMatcherTable`

The map value changes from the tuple `(Arc<dyn TableProvider>, SpjNormalForm)` to a named struct:

```rust
pub struct ViewMatcherTable {
    pub normal_form: Arc<SpjNormalForm>,
    pub table: Arc<dyn TableProvider>,
}
```

The `SpjNormalForm` is now behind an `Arc` so snapshot clones are cheap.

### Copy-on-write candidate set

```rust
pub struct ViewMatcher {
    mv_plans: RwLock<Arc<HashMap<TableReference, ViewMatcherTable>>>,
    update_lock: futures::lock::Mutex<()>,
}
```

`OptimizerRule::rewrite` takes the read lock only long enough to clone the `Arc`, then does all rewriting against that immutable snapshot — so a concurrent catalog update can never mutate the map out from under an in-flight rewrite, and rewrites never block on updates. Mutations clone the inner `HashMap`, apply the change, and swap in a new `Arc`. Adds a `parking_lot` dependency for the `RwLock`.

`ViewMatchingRewriter` correspondingly holds the snapshot (`Arc<HashMap<..>>`) instead of a `&ViewMatcher` borrow.

### Three ways to maintain the set

| Method | Behavior |
| --- | --- |
| `update_candidates(&state)` | Re-scans every catalog and atomically replaces the whole set. |
| `refresh_candidate(&state, table_ref)` | Re-analyzes **one** table and inserts/replaces/removes just its entry. Returns whether the table is now a candidate. |
| `invalidate_candidate(&state, table_ref)` | Immediately drops one entry without any analysis. Returns whether one was removed. |

`refresh_candidate` is the cheap path when a single table changed — it analyzes only that table instead of walking every catalog. It removes the entry when the table was dropped, is not a materialized view, or has `use_in_query_rewrite = false` / no SPJ normal form.

The full-scan and single-table paths share one `build_candidate` helper, so a candidate is computed identically no matter which entry point produced it.

## Correctness details

**Table references are resolved.** Both `refresh_candidate` and `invalidate_candidate` resolve the incoming reference against the session's default catalog/schema before touching the map. The full scan stores fully-qualified keys, so without this a bare `"mv"` would create a second, duplicate entry rather than updating `datafusion.public.mv`. Bare, partial, and fully-qualified spellings all address the same entry.

**The provider is read from the catalog, not from the caller.** `refresh_candidate` looks the `TableProvider` up through `catalog_list()` rather than accepting one as an argument, so an entry always reflects what is actually registered — a caller can't inject a provider that was already replaced.

**Mutations are serialized.** `update_lock` (an async mutex, held across the `.await` on analysis) ensures a slow full rescan cannot overwrite a newer single-table refresh with stale results. The candidate set converges to the catalog state seen by the last completed call.

**Failures fail closed.** If a refresh errors — catalog lookup failure or analyzer error — the table's candidate is *removed* and the error returned, rather than leaving a possibly-stale entry live for rewriting. Only the failing table is affected; other candidates are untouched. The table becomes a candidate again on the next successful refresh.

## Breaking API changes

- `ViewMatcher::mv_plans()` returns `Arc<HashMap<TableReference, ViewMatcherTable>>` (an owned snapshot) instead of `&HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)>`. A reference can't be handed out from behind the lock.
- `get_potential_mv_candidates_for_table()` returns `Vec<(TableReference, ViewMatcherTable)>` instead of the 3-tuple `Vec<(TableReference, Arc<dyn TableProvider>, &SpjNormalForm)>`.

## Tests

Six new tests in `tests_incremental_candidates` covering:

- `refresh_candidate` ignores non-materialized tables and unknown tables — and asserts via `Arc::ptr_eq` that a no-op does not swap the snapshot at all
- `refresh_candidate` normalizes table refs: a bare ref updates the fully-qualified entry rather than creating a duplicate; after deregistration any spelling removes it
- `invalidate_candidate` removes an entry addressed by a bare ref, is a no-op (no snapshot swap) when absent, and a later refresh brings the candidate back
- analyzer failure during refresh removes only the failing table's candidate (via an injected `AnalyzerRule` that poisons specific plans)
- catalog lookup failure during refresh removes only the failing table's candidate (via a `SchemaProvider` whose `table()` can be made to error)

Full suite: 71 lib tests + 1 integration test pass; `cargo clippy --tests --all-features -- -D warnings` and `cargo fmt --check` are clean.

## Rebase note

Rebased onto `branch-54` on top of #55 (RewriteReadiness / per-branch `CandidateMetadata`). Both changes rewrote the candidate-generation loop in `f_down`; the merged version keeps #55's `NotReady` filtering and readiness propagation while reading through `ViewMatcherTable` and the immutable snapshot. Readiness is still read from the live provider on each rewrite, so #55's lazy-index warming behavior is preserved. Every commit in the branch compiles independently.
