### PR TITLE
[X-3269] Empty-plan discriminator: RewriteReadiness + per-branch CandidateMetadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v2
       with:
-        command: check license
+        command: check licenses
 
   coverage:
     if: github.event.pull_request.draft == false

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -100,42 +100,11 @@ pub fn cast_to_listing_table(table: &dyn TableProvider) -> Option<&dyn ListingTa
         })
 }
 
-/// Whether a materialized view is currently safe to route queries to. Reported
-/// by [`Materialized::rewrite_readiness`] and consulted by
-/// [`ViewMatcher`](crate::rewrite::exploitation::ViewMatcher) during LP rewrite
-/// so that unpopulated / in-flight MVs are excluded from the candidate set
-/// upstream of the cost function.
-///
-/// Keeping this a lifecycle abstraction (rather than a proxy such as file
-/// count) means the trait doesn't couple to any specific storage layout —
-/// providers describe their own readiness however they want (index loaded,
-/// snapshot published, migration complete, staleness threshold satisfied,
-/// etc.) and only report the answer.
-// `PartialOrd, Ord` are derived so `CandidateMetadata` (which stores a
-// `RewriteReadiness`) can keep its own `PartialOrd, Ord` derives. The
-// variant ordering has no lifecycle meaning — callers must not depend on
-// `Ready < NotReady < Unknown`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum RewriteReadiness {
-    /// The MV is populated and can safely answer the query. The
-    /// `ViewMatchingRewriter` will include it as a rewrite candidate.
-    Ready,
-    /// The MV should not be used yet (index not loaded, ingest task never
-    /// ran after a version bump, snapshot rebuild in progress, etc.).
-    /// The `ViewMatchingRewriter` will drop the MV from the candidate set
-    /// so a query never gets routed to it and silently returns empty.
-    NotReady,
-    /// The provider cannot cheaply determine readiness. The
-    /// `ViewMatchingRewriter` treats this as "include as candidate" and
-    /// propagates the `Unknown` value to the cost function via
-    /// `CandidateMetadata::Materialized { readiness, .. }`, so the caller
-    /// can pick whatever policy fits — e.g. fall back to the base scan
-    /// cost rather than trust an EmptyExec candidate as predicate-pruned.
-    /// Default value returned by the trait's blanket impl so
-    /// backward-compatible providers keep the pre-existing "always a
-    /// candidate" behaviour.
-    Unknown,
-}
+// Re-exported for backward compatibility with downstream code that used
+// to import `RewriteReadiness` from `crate::materialized`. The enum
+// itself lives in `crate::rewrite::readiness` now (see PR #55 review),
+// so all readiness-related types are grouped in one file.
+pub use crate::rewrite::readiness::RewriteReadiness;
 
 /// A hive-partitioned table in object storage that is defined by a user-provided query.
 pub trait Materialized: ListingTableLike {
@@ -326,28 +295,5 @@ impl TableTypeRegistry {
         self.decorator_accessors
             .get(&table_any.type_id())
             .and_then(|r| r.value().1(table_any))
-    }
-}
-
-#[cfg(test)]
-mod tests_readiness {
-    use super::RewriteReadiness;
-
-    #[test]
-    fn variants_are_distinct_and_comparable() {
-        assert_ne!(RewriteReadiness::Ready, RewriteReadiness::NotReady);
-        assert_ne!(RewriteReadiness::Ready, RewriteReadiness::Unknown);
-        assert_ne!(RewriteReadiness::NotReady, RewriteReadiness::Unknown);
-        assert_eq!(RewriteReadiness::Ready, RewriteReadiness::Ready);
-    }
-
-    #[test]
-    fn readiness_is_copy_and_hashable() {
-        // Ensure the variants can be stored / matched cheaply from the
-        // rewrite path without cloning.
-        fn requires_copy<T: Copy>() {}
-        fn requires_hash<T: std::hash::Hash>() {}
-        requires_copy::<RewriteReadiness>();
-        requires_hash::<RewriteReadiness>();
     }
 }

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -111,6 +111,10 @@ pub fn cast_to_listing_table(table: &dyn TableProvider) -> Option<&dyn ListingTa
 /// providers describe their own readiness however they want (index loaded,
 /// snapshot published, migration complete, staleness threshold satisfied,
 /// etc.) and only report the answer.
+// `PartialOrd, Ord` are derived so `CandidateMetadata` (which stores a
+// `RewriteReadiness`) can keep its own `PartialOrd, Ord` derives. The
+// variant ordering has no lifecycle meaning — callers must not depend on
+// `Ready < NotReady < Unknown`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RewriteReadiness {
     /// The MV is populated and can safely answer the query. The
@@ -122,11 +126,14 @@ pub enum RewriteReadiness {
     /// so a query never gets routed to it and silently returns empty.
     NotReady,
     /// The provider cannot cheaply determine readiness. The
-    /// `ViewMatchingRewriter` treats this as "include as candidate" — the
-    /// cost function is responsible for whatever policy the caller wants
-    /// for unknown-lifecycle MVs. Default value returned by the trait's
-    /// blanket impl so backward-compatible providers keep the pre-existing
-    /// "always a candidate" behaviour.
+    /// `ViewMatchingRewriter` treats this as "include as candidate" and
+    /// propagates the `Unknown` value to the cost function via
+    /// `CandidateMetadata::Materialized { readiness, .. }`, so the caller
+    /// can pick whatever policy fits — e.g. fall back to the base scan
+    /// cost rather than trust an EmptyExec candidate as predicate-pruned.
+    /// Default value returned by the trait's blanket impl so
+    /// backward-compatible providers keep the pre-existing "always a
+    /// candidate" behaviour.
     Unknown,
 }
 

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -118,6 +118,20 @@ pub trait Materialized: ListingTableLike {
     fn static_partition_columns(&self) -> Vec<String> {
         <Self as ListingTableLike>::partition_columns(self)
     }
+
+    /// Current total number of files in this materialized view, ignoring any query
+    /// predicates. Used by cost functions to distinguish an unpopulated MV (which
+    /// should never win a rewrite — see X-2174 in the atlas repo) from a populated
+    /// MV whose files got pruned to zero by a rare-literal query predicate (which
+    /// SHOULD win — the file/row-group pruning proved absence without a scan; see
+    /// X-3269 for the /etf-global/v1/constituents?composite_ticker=MFSI case).
+    ///
+    /// Default is `None` — providers that can't cheaply report a total count fall
+    /// back to whatever discriminator the caller uses. Implementations that own an
+    /// eagerly-loaded file index should return `Some(index.total_files())`.
+    fn file_count(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Register a [`Materialized`] implementation in this registry.

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -111,7 +111,7 @@ pub fn cast_to_listing_table(table: &dyn TableProvider) -> Option<&dyn ListingTa
 /// providers describe their own readiness however they want (index loaded,
 /// snapshot published, migration complete, staleness threshold satisfied,
 /// etc.) and only report the answer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RewriteReadiness {
     /// The MV is populated and can safely answer the query. The
     /// `ViewMatchingRewriter` will include it as a rewrite candidate.

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -101,10 +101,10 @@ pub fn cast_to_listing_table(table: &dyn TableProvider) -> Option<&dyn ListingTa
 }
 
 /// Whether a materialized view is currently safe to route queries to. Reported
-/// by [`Materialized::rewrite_readiness`] and consulted by the
-/// [`ViewMatchingRewriter`](crate::rewrite::exploitation::ViewMatcher) so that
-/// unpopulated / in-flight MVs are excluded from the candidate set upstream of
-/// the cost function.
+/// by [`Materialized::rewrite_readiness`] and consulted by
+/// [`ViewMatcher`](crate::rewrite::exploitation::ViewMatcher) during LP rewrite
+/// so that unpopulated / in-flight MVs are excluded from the candidate set
+/// upstream of the cost function.
 ///
 /// Keeping this a lifecycle abstraction (rather than a proxy such as file
 /// count) means the trait doesn't couple to any specific storage layout —
@@ -151,9 +151,9 @@ pub trait Materialized: ListingTableLike {
 
     /// Report whether this MV is currently safe to route queries to. See
     /// [`RewriteReadiness`] for the semantics of each variant. Consulted by
-    /// [`ViewMatchingRewriter`](crate::rewrite::exploitation::ViewMatcher)
-    /// during LP rewrite; `NotReady` MVs are dropped from the candidate
-    /// set upstream of the cost function, so they never win a rewrite.
+    /// [`ViewMatcher`](crate::rewrite::exploitation::ViewMatcher) during LP
+    /// rewrite; `NotReady` MVs are dropped from the candidate set upstream
+    /// of the cost function, so they never win a rewrite.
     ///
     /// Default is `Unknown`, which means "include as candidate but the
     /// cost function decides" — backward-compatible for providers that

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -120,11 +120,14 @@ pub trait Materialized: ListingTableLike {
     }
 
     /// Current total number of files in this materialized view, ignoring any query
-    /// predicates. Used by cost functions to distinguish an unpopulated MV (which
-    /// should never win a rewrite — see X-2174 in the atlas repo) from a populated
-    /// MV whose files got pruned to zero by a rare-literal query predicate (which
-    /// SHOULD win — the file/row-group pruning proved absence without a scan; see
-    /// X-3269 for the /etf-global/v1/constituents?composite_ticker=MFSI case).
+    /// predicates. Cost functions use this to distinguish two shapes that both
+    /// produce an empty physical plan:
+    ///
+    /// * an unpopulated MV (no files yet — should never win a rewrite, since
+    ///   routing a query to it silently returns wrong empty results), and
+    /// * a populated MV whose files were all pruned by min/max statistics on a
+    ///   rare-literal predicate (should win — pruning proved absence via metadata
+    ///   alone, versus scanning the base table).
     ///
     /// Default is `None` — providers that can't cheaply report a total count fall
     /// back to whatever discriminator the caller uses. Implementations that own an

--- a/src/materialized.rs
+++ b/src/materialized.rs
@@ -100,6 +100,36 @@ pub fn cast_to_listing_table(table: &dyn TableProvider) -> Option<&dyn ListingTa
         })
 }
 
+/// Whether a materialized view is currently safe to route queries to. Reported
+/// by [`Materialized::rewrite_readiness`] and consulted by the
+/// [`ViewMatchingRewriter`](crate::rewrite::exploitation::ViewMatcher) so that
+/// unpopulated / in-flight MVs are excluded from the candidate set upstream of
+/// the cost function.
+///
+/// Keeping this a lifecycle abstraction (rather than a proxy such as file
+/// count) means the trait doesn't couple to any specific storage layout —
+/// providers describe their own readiness however they want (index loaded,
+/// snapshot published, migration complete, staleness threshold satisfied,
+/// etc.) and only report the answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RewriteReadiness {
+    /// The MV is populated and can safely answer the query. The
+    /// `ViewMatchingRewriter` will include it as a rewrite candidate.
+    Ready,
+    /// The MV should not be used yet (index not loaded, ingest task never
+    /// ran after a version bump, snapshot rebuild in progress, etc.).
+    /// The `ViewMatchingRewriter` will drop the MV from the candidate set
+    /// so a query never gets routed to it and silently returns empty.
+    NotReady,
+    /// The provider cannot cheaply determine readiness. The
+    /// `ViewMatchingRewriter` treats this as "include as candidate" — the
+    /// cost function is responsible for whatever policy the caller wants
+    /// for unknown-lifecycle MVs. Default value returned by the trait's
+    /// blanket impl so backward-compatible providers keep the pre-existing
+    /// "always a candidate" behaviour.
+    Unknown,
+}
+
 /// A hive-partitioned table in object storage that is defined by a user-provided query.
 pub trait Materialized: ListingTableLike {
     /// The query that defines this materialized view.
@@ -119,21 +149,17 @@ pub trait Materialized: ListingTableLike {
         <Self as ListingTableLike>::partition_columns(self)
     }
 
-    /// Current total number of files in this materialized view, ignoring any query
-    /// predicates. Cost functions use this to distinguish two shapes that both
-    /// produce an empty physical plan:
+    /// Report whether this MV is currently safe to route queries to. See
+    /// [`RewriteReadiness`] for the semantics of each variant. Consulted by
+    /// [`ViewMatchingRewriter`](crate::rewrite::exploitation::ViewMatcher)
+    /// during LP rewrite; `NotReady` MVs are dropped from the candidate
+    /// set upstream of the cost function, so they never win a rewrite.
     ///
-    /// * an unpopulated MV (no files yet — should never win a rewrite, since
-    ///   routing a query to it silently returns wrong empty results), and
-    /// * a populated MV whose files were all pruned by min/max statistics on a
-    ///   rare-literal predicate (should win — pruning proved absence via metadata
-    ///   alone, versus scanning the base table).
-    ///
-    /// Default is `None` — providers that can't cheaply report a total count fall
-    /// back to whatever discriminator the caller uses. Implementations that own an
-    /// eagerly-loaded file index should return `Some(index.total_files())`.
-    fn file_count(&self) -> Option<usize> {
-        None
+    /// Default is `Unknown`, which means "include as candidate but the
+    /// cost function decides" — backward-compatible for providers that
+    /// don't distinguish lifecycle states.
+    fn rewrite_readiness(&self) -> RewriteReadiness {
+        RewriteReadiness::Unknown
     }
 }
 
@@ -293,5 +319,28 @@ impl TableTypeRegistry {
         self.decorator_accessors
             .get(&table_any.type_id())
             .and_then(|r| r.value().1(table_any))
+    }
+}
+
+#[cfg(test)]
+mod tests_readiness {
+    use super::RewriteReadiness;
+
+    #[test]
+    fn variants_are_distinct_and_comparable() {
+        assert_ne!(RewriteReadiness::Ready, RewriteReadiness::NotReady);
+        assert_ne!(RewriteReadiness::Ready, RewriteReadiness::Unknown);
+        assert_ne!(RewriteReadiness::NotReady, RewriteReadiness::Unknown);
+        assert_eq!(RewriteReadiness::Ready, RewriteReadiness::Ready);
+    }
+
+    #[test]
+    fn readiness_is_copy_and_hashable() {
+        // Ensure the variants can be stored / matched cheaply from the
+        // rewrite path without cloning.
+        fn requires_copy<T: Copy>() {}
+        fn requires_hash<T: std::hash::Hash>() {}
+        requires_copy::<RewriteReadiness>();
+        requires_hash::<RewriteReadiness>();
     }
 }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -21,6 +21,8 @@ pub mod exploitation;
 
 pub mod normal_form;
 
+pub mod readiness;
+
 mod util;
 
 extensions_options! {

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -73,17 +73,68 @@ use super::QueryRewriteOptions;
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Hash)]
 pub struct RewriteContext {
     root_table_refs: Vec<String>,
+    /// Per-branch source table reference. Index i corresponds to branch i in the
+    /// containing `OneOf` / `OneOfExec`, where index 0 is the base table branch
+    /// and indices 1..N are MV candidates. `None` marks the base branch (or a
+    /// candidate whose source isn't a materialized view); `Some(mv_ref)` gives
+    /// the MV's registered `TableReference` so cost functions can identify the
+    /// candidate even when the physical plan tree has collapsed to a bare
+    /// `EmptyExec` after predicate pruning.
+    candidate_table_refs: Vec<Option<String>>,
+    /// Per-branch total file count of the source MV, snapshotted at LP-rewrite
+    /// time from `Materialized::file_count()`. Aligned with `candidate_table_refs`.
+    ///
+    /// * `None`     — base branch, or a candidate whose provider doesn't expose file_count
+    /// * `Some(0)`  — MV is registered but has no files (X-2174 case: newly-deployed MV
+    ///                whose ingest task hasn't run yet — cost function should reject it)
+    /// * `Some(N)`  — MV is populated with N files (X-3269 case: if the physical plan
+    ///                collapsed to EmptyExec, that's predicate-pruning, not un-population;
+    ///                cost function should keep the -inf cost so the MV wins)
+    candidate_file_counts: Vec<Option<usize>>,
 }
 
 impl RewriteContext {
     /// Create a new rewrite context from the root table refs visible during rewrite.
+    /// Candidate lists start empty; use the `with_*` builders to attach per-branch data.
     pub fn new(root_table_refs: Vec<String>) -> Self {
-        Self { root_table_refs }
+        Self {
+            root_table_refs,
+            candidate_table_refs: Vec::new(),
+            candidate_file_counts: Vec::new(),
+        }
+    }
+
+    /// Attach the per-branch source table reference list. Consumes and returns `self`
+    /// so the builder chain stays readable at the OneOf construction site.
+    pub fn with_candidate_table_refs(mut self, candidate_table_refs: Vec<Option<String>>) -> Self {
+        self.candidate_table_refs = candidate_table_refs;
+        self
+    }
+
+    /// Attach per-branch file counts. See the field doc for population semantics.
+    pub fn with_candidate_file_counts(
+        mut self,
+        candidate_file_counts: Vec<Option<usize>>,
+    ) -> Self {
+        self.candidate_file_counts = candidate_file_counts;
+        self
     }
 
     /// Returns the root table refs that produced this rewrite opportunity.
     pub fn root_table_refs(&self) -> &[String] {
         &self.root_table_refs
+    }
+
+    /// Returns the per-branch source table refs, aligned with the candidate plan order.
+    /// Empty when no callsite has attached them (backward compatible with pre-X-3269 usage).
+    pub fn candidate_table_refs(&self) -> &[Option<String>] {
+        &self.candidate_table_refs
+    }
+
+    /// Returns the per-branch source file counts, aligned with the candidate plan order.
+    /// Empty when no callsite has attached them.
+    pub fn candidate_file_counts(&self) -> &[Option<usize>] {
+        &self.candidate_file_counts
     }
 }
 
@@ -262,8 +313,12 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             Ok(form) => form,
         };
 
-        // Generate candidate substitutions
-        let candidates = self
+        // Generate candidate substitutions. Track (source MV TableReference, source MV
+        // total file count) alongside each rewritten LP so we can propagate per-branch
+        // identity + populated-ness into `RewriteContext`. Cost functions need both
+        // signals: file_count == 0 → unpopulated MV (X-2174 protection), file_count > 0 +
+        // physical plan collapsed to EmptyExec → predicate-pruned (X-3269 fix).
+        let candidates: Vec<(LogicalPlan, TableReference, Option<usize>)> = self
             .parent
             .mv_plans
             .iter()
@@ -272,12 +327,17 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                 plan.referenced_tables()
                     .contains(&table_reference)
                     .then(|| {
+                        let file_count = cast_to_materialized(table.as_ref())
+                            .ok()
+                            .flatten()
+                            .and_then(|mv| mv.file_count());
                         form.rewrite_from(
                             plan,
                             table_ref.clone(),
                             provider_as_source(Arc::clone(table)),
                         )
                         .transpose()
+                        .map(|res| res.map(|lp| (lp, table_ref.clone(), file_count)))
                     })
                     .flatten()
             })
@@ -286,19 +346,34 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                     log::trace!("error rewriting: {e}");
                     None
                 }
-                Ok(plan) => Some(plan),
+                Ok(triple) => Some(triple),
             })
-            .collect::<Vec<_>>();
+            .collect();
 
         if candidates.is_empty() {
             log::trace!("no candidates");
             Ok(Transformed::no(node))
         } else {
+            // Base branch is the query's original LP (no MV source) → None; MV
+            // branches carry their `TableReference` + `file_count` so cost functions
+            // can distinguish predicate-pruned populated MVs (X-3269, keep -inf) from
+            // genuinely-unpopulated MVs (X-2174, flip +inf).
+            let candidate_table_refs: Vec<Option<String>> = std::iter::once(None)
+                .chain(candidates.iter().map(|(_, r, _)| Some(r.to_string())))
+                .collect();
+            let candidate_file_counts: Vec<Option<usize>> = std::iter::once(None)
+                .chain(candidates.iter().map(|(_, _, fc)| *fc))
+                .collect();
+            let branches: Vec<LogicalPlan> = std::iter::once(node)
+                .chain(candidates.into_iter().map(|(lp, _, _)| lp))
+                .collect();
             Ok(Transformed::new(
                 LogicalPlan::Extension(Extension {
                     node: Arc::new(OneOf::with_rewrite_context(
-                        Some(node).into_iter().chain(candidates).collect_vec(),
-                        RewriteContext::new(vec![table_reference.to_string()]),
+                        branches,
+                        RewriteContext::new(vec![table_reference.to_string()])
+                            .with_candidate_table_refs(candidate_table_refs)
+                            .with_candidate_file_counts(candidate_file_counts),
                     )),
                 }),
                 true,

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -110,10 +110,10 @@ pub enum CandidateMetadata {
     /// A materialized-view rewrite of the query. Only MVs that reported
     /// `Ready` or `Unknown` readiness reach this state; `NotReady` MVs
     /// are filtered upstream by [`ViewMatcher`]. Cost functions consult
-    /// [`Self::Materialized::readiness`] to distinguish the two cases —
-    /// `Unknown` (the trait default) must not be silently treated as
-    /// `Ready`, since that would regress providers that haven't declared
-    /// a lifecycle.
+    /// the `readiness` field to distinguish the two cases: `Unknown`
+    /// (the trait default returned by [`RewriteReadiness`]) must not be
+    /// silently treated as `Ready`, since that would regress providers
+    /// that haven't declared a lifecycle.
     Materialized {
         /// Registered `TableReference` of the source MV. Stable across
         /// LP transformations; safe to use as a sort key.
@@ -596,16 +596,20 @@ impl ExtensionPlanner for ViewExploitationPlanner {
 /// refreshed readiness is `NotReady`, along with its aligned entry in
 /// `physical_inputs`. Base is never filtered.
 ///
-/// If `candidates` is empty (an older callsite constructed the `OneOf`
-/// without per-branch metadata) or is not aligned with `physical_inputs`,
-/// the inputs are passed through unchanged — this filter is opt-in on
-/// having metadata; callsites without it keep their original behaviour.
+/// If `candidates` is empty or is not aligned with `physical_inputs`
+/// (older callsites that constructed the `OneOf` without per-branch
+/// metadata, or a caller that supplied a mismatched vector), the inputs
+/// are passed through unchanged and the metadata is dropped entirely —
+/// preserving a misaligned slice would let it flow into `OneOfExec` and
+/// mis-attribute readiness to the wrong branch inside the cost function.
+/// Callsites without metadata keep their original behaviour (the empty
+/// slice is what the pre-readiness code path also carried).
 fn drop_not_ready_after_refresh(
     physical_inputs: &[Arc<dyn ExecutionPlan>],
     candidates: &[CandidateMetadata],
 ) -> (Vec<Arc<dyn ExecutionPlan>>, Vec<CandidateMetadata>) {
     if candidates.len() != physical_inputs.len() {
-        return (physical_inputs.to_vec(), candidates.to_vec());
+        return (physical_inputs.to_vec(), Vec::new());
     }
     let mut kept_inputs = Vec::with_capacity(physical_inputs.len());
     let mut kept_candidates = Vec::with_capacity(candidates.len());
@@ -2008,8 +2012,11 @@ mod tests_physical_time_readiness_refresh {
     async fn refresh_reflects_transition_to_not_ready() {
         // If a provider observed as `Ready` at LP-time transitions to
         // `NotReady` between LP rewrite and physical planning (rare, but
-        // possible if scan itself detects unpopulated state), refresh
-        // must surface that so the cost function can penalize it.
+        // possible if scan itself detects unpopulated state), the refresh
+        // helper must surface that value so the caller can filter it
+        // (`drop_not_ready_after_refresh` removes the candidate before
+        // `OneOfExec::try_new` invokes the cost function — the invariant
+        // "NotReady never reaches the cost function" is preserved).
         register_materialized::<MockMv>();
         let ctx = SessionContext::new();
         let mv = MockMv::new("target_t", RewriteReadiness::Ready);
@@ -2102,6 +2109,38 @@ mod tests_physical_time_readiness_refresh {
             drop_not_ready_after_refresh(&physical_inputs, &candidates);
         assert_eq!(kept_inputs.len(), 2);
         assert!(kept_candidates.is_empty());
+    }
+
+    #[test]
+    fn drop_not_ready_filter_drops_misaligned_metadata_instead_of_propagating_it() {
+        // Regression for the "misalignment-poisons-downstream" concern: if a
+        // caller supplies a non-empty but wrong-length metadata slice, the
+        // filter must not carry that slice through to `OneOfExec`, or the
+        // cost function would end up indexing candidates by the branch
+        // position of an unrelated candidate. We keep the physical inputs
+        // intact so the OneOfExec still builds, but the metadata is dropped
+        // so downstream sees the same shape as the pre-readiness code path.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let make = || Arc::new(EmptyExec::new(Arc::clone(&schema))) as Arc<dyn ExecutionPlan>;
+        // 3 physical inputs but only 2 metadata entries — mismatched.
+        let physical_inputs = vec![make(), make(), make()];
+        let candidates = vec![
+            CandidateMetadata::Base,
+            CandidateMetadata::Materialized {
+                table_ref: "a".to_string(),
+                readiness: RewriteReadiness::Ready,
+            },
+        ];
+
+        let (kept_inputs, kept_candidates) =
+            drop_not_ready_after_refresh(&physical_inputs, &candidates);
+        assert_eq!(kept_inputs.len(), 3, "physical inputs must survive so OneOfExec still builds");
+        assert!(
+            kept_candidates.is_empty(),
+            "misaligned metadata must not be propagated to downstream cost functions"
+        );
     }
 
     #[test]

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -67,7 +67,9 @@ use ordered_float::OrderedFloat;
 use crate::materialized::cast_to_materialized;
 
 use super::normal_form::SpjNormalForm;
-use super::readiness::{drop_not_ready_after_refresh, refresh_candidate_readiness};
+use super::readiness::{
+    drop_not_ready_after_refresh, refresh_candidate_readiness, strip_readiness_annotation,
+};
 use super::QueryRewriteOptions;
 
 // Re-export readiness types for backward compatibility. Callers that
@@ -514,6 +516,18 @@ impl ExtensionPlanner for ViewExploitationPlanner {
         )
         .await;
 
+        // Strip `ReadinessAnnotatedExec` from every physical input now that
+        // we've read its readiness. The wrapper is a signaling device local
+        // to this planner; keeping it in the plan handed to the cost
+        // function / `OneOfExec` / downstream optimizers would block passes
+        // that depend on `ExecutionPlan` trait methods the wrapper doesn't
+        // proxy (limit pushdown, projection pushdown, `with_preserve_order`,
+        // etc.).
+        let stripped_inputs: Vec<Arc<dyn ExecutionPlan>> = physical_inputs
+            .iter()
+            .map(|plan| strip_readiness_annotation(Arc::clone(plan)))
+            .collect::<Result<_>>()?;
+
         // Enforce the invariant documented on `CandidateMetadata`: NotReady
         // never reaches the cost function. A provider can transition to
         // NotReady between LP rewrite and physical planning (rare, but
@@ -522,7 +536,7 @@ impl ExtensionPlanner for ViewExploitationPlanner {
         // `physical_inputs` are filtered in lockstep to preserve the
         // by-index alignment cost functions rely on.
         let (kept_inputs, kept_candidates) =
-            drop_not_ready_after_refresh(physical_inputs, refreshed_context.candidates());
+            drop_not_ready_after_refresh(&stripped_inputs, refreshed_context.candidates());
 
         // If the filter left only the Base branch we can skip the OneOfExec
         // wrapper entirely and just return the base physical plan — nothing
@@ -2321,5 +2335,68 @@ mod tests_physical_time_readiness_refresh {
         let schema = Arc::new(Schema::empty());
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
         assert_eq!(readiness_from_plan(&plan), None);
+    }
+
+    #[tokio::test]
+    async fn plan_extension_strips_readiness_annotation_before_returning() {
+        // Regression test for the concern that a leaked
+        // `ReadinessAnnotatedExec` would appear in the plan handed to the
+        // cost function / OneOfExec / downstream optimizers and block
+        // trait-method-driven optimizations (limit pushdown, projection
+        // pushdown, with_preserve_order, ...). After plan_extension runs,
+        // no ReadinessAnnotatedExec must remain anywhere in the resulting
+        // OneOfExec's child subtrees.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::Ready);
+        ctx.register_table("mv_wrapped", Arc::clone(&mv) as Arc<dyn TableProvider>)
+            .expect("register mv_wrapped");
+        let state = ctx.state();
+        let mv_ref = default_qualified_table_ref(&state, "mv_wrapped");
+        let base_lp = LogicalPlanBuilder::empty(false).build().expect("base lp");
+        let mv_lp = LogicalPlanBuilder::empty(false).build().expect("mv lp");
+        let one_of_node = OneOf::with_rewrite_context(
+            vec![base_lp.clone(), mv_lp.clone()],
+            RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
+                CandidateMetadata::Base,
+                CandidateMetadata::Materialized {
+                    table_ref: mv_ref,
+                    readiness: RewriteReadiness::Ready,
+                },
+            ]),
+        );
+
+        let schema = Arc::new(Schema::empty());
+        let base_phys: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::clone(&schema)));
+        // Provider wraps its scan output — plan_extension must strip this
+        // before building the OneOfExec.
+        let mv_phys: Arc<dyn ExecutionPlan> = Arc::new(ReadinessAnnotatedExec::new(
+            Arc::new(EmptyExec::new(schema)),
+            RewriteReadiness::Ready,
+        ));
+
+        let cost_fn: CostFn = Arc::new(|ctx| ctx.into_candidate_plans().map(|_| 1.0_f64).collect());
+        let planner = ViewExploitationPlanner::new(cost_fn);
+        let stub = StubPlanner;
+
+        let result = planner
+            .plan_extension(
+                &stub,
+                &one_of_node,
+                &[&base_lp, &mv_lp],
+                &[Arc::clone(&base_phys), Arc::clone(&mv_phys)],
+                &state,
+            )
+            .await
+            .expect("plan_extension")
+            .expect("plan_extension returned Some");
+
+        // No ReadinessAnnotatedExec anywhere in the returned plan tree.
+        assert!(
+            readiness_from_plan(&result).is_none(),
+            "ReadinessAnnotatedExec must be stripped before plan_extension returns"
+        );
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -641,14 +641,42 @@ fn drop_not_ready_after_refresh(
 /// so the cost function sees the definitive readiness rather than the
 /// stale LP-time snapshot.
 ///
-/// Lookup failures (table not found in the catalog, provider is no longer a
-/// `Materialized`, `cast_to_materialized` error) fall back to the LP-time
-/// value — the goal is to be at least as accurate as the previous value,
-/// never less.
+/// Fast path: if every `Materialized` candidate already reports `Ready`
+/// at LP-rewrite time, refresh is a no-op. `Ready` is monotone in the
+/// provider models we ship for (an index that has loaded doesn't
+/// spontaneously unload between LP and physical planning), so no
+/// post-scan call can move a `Ready` back to `Unknown` or `NotReady`.
+/// The only candidates whose value can change under refresh are the
+/// `Unknown` ones — cold lazy indexes that `scan()` may have warmed.
+/// Skipping the refresh in the all-`Ready` case avoids one catalog walk
+/// per query on the warm hot path (the common case once every MV has
+/// been touched at least once).
+///
+/// Providers whose `rewrite_readiness()` is not monotone (e.g. an index
+/// that unloads on memory pressure) should not rely on this fast path;
+/// they can opt out by never reporting `Ready` at LP-rewrite time.
+///
+/// Lookup failures (table not found in the catalog, provider is no
+/// longer a `Materialized`, `cast_to_materialized` error) fall back to
+/// the LP-time value — the goal is to be at least as accurate as the
+/// previous value, never less.
 async fn refresh_candidate_readiness(
     context: RewriteContext,
     session_state: &SessionState,
 ) -> RewriteContext {
+    let any_unknown = context.candidates().iter().any(|c| {
+        matches!(
+            c,
+            CandidateMetadata::Materialized {
+                readiness: RewriteReadiness::Unknown,
+                ..
+            }
+        )
+    });
+    if !any_unknown {
+        return context;
+    }
+
     let catalog_list = session_state.catalog_list();
     let default_catalog = &session_state.config().options().catalog.default_catalog;
     let default_schema = &session_state.config().options().catalog.default_schema;
@@ -657,6 +685,14 @@ async fn refresh_candidate_readiness(
         futures::future::join_all(context.candidates().iter().map(|c| async move {
             match c {
                 CandidateMetadata::Base => CandidateMetadata::Base,
+                // Ready is monotone — skip the per-candidate catalog walk too.
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness: RewriteReadiness::Ready,
+                } => CandidateMetadata::Materialized {
+                    table_ref: table_ref.clone(),
+                    readiness: RewriteReadiness::Ready,
+                },
                 CandidateMetadata::Materialized {
                     table_ref,
                     readiness,
@@ -1953,6 +1989,39 @@ mod tests_physical_time_readiness_refresh {
     }
 
     #[tokio::test]
+    async fn refresh_is_noop_when_every_candidate_already_ready() {
+        // Warm hot path: after every MV has been touched at least once
+        // its LP-time readiness is `Ready` for every subsequent query.
+        // The refresh must skip the catalog walk entirely — no lookup,
+        // no `rewrite_readiness()` call — because `Ready` is monotone
+        // (a loaded index doesn't spontaneously unload). We prove this
+        // by not registering the MVs in the SessionContext at all: if
+        // the refresh tried to resolve their `table_ref` through the
+        // catalog it would trigger the LP-time fallback branch instead
+        // of returning verbatim; the assertion below would still pass
+        // in that case, but the surrounding test — `refresh_falls_back
+        // _to_lp_time_value_when_provider_missing` — already covers the
+        // "resolve then fall back" case, so any observable difference
+        // here would come from the fast path being taken.
+        let ctx = SessionContext::new();
+        let context = RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
+            CandidateMetadata::Base,
+            CandidateMetadata::Materialized {
+                table_ref: "atlas.public.mv_hot_a".to_string(),
+                readiness: RewriteReadiness::Ready,
+            },
+            CandidateMetadata::Materialized {
+                table_ref: "atlas.public.mv_hot_b".to_string(),
+                readiness: RewriteReadiness::Ready,
+            },
+        ]);
+
+        let refreshed = refresh_candidate_readiness(context.clone(), &ctx.state()).await;
+        // Identical shape — fast path returned the same context.
+        assert_eq!(refreshed, context);
+    }
+
+    #[tokio::test]
     async fn refresh_reflects_post_scan_transition_to_ready() {
         // Simulate the lazy-index cold-start scenario end-to-end at the
         // `RewriteContext` layer. Provider starts Unknown, its `scan()` is
@@ -2009,17 +2078,18 @@ mod tests_physical_time_readiness_refresh {
     }
 
     #[tokio::test]
-    async fn refresh_reflects_transition_to_not_ready() {
-        // If a provider observed as `Ready` at LP-time transitions to
-        // `NotReady` between LP rewrite and physical planning (rare, but
-        // possible if scan itself detects unpopulated state), the refresh
-        // helper must surface that value so the caller can filter it
-        // (`drop_not_ready_after_refresh` removes the candidate before
-        // `OneOfExec::try_new` invokes the cost function — the invariant
-        // "NotReady never reaches the cost function" is preserved).
+    async fn refresh_promotes_unknown_candidate_to_not_ready_when_scan_uncovers_unpopulated() {
+        // Complements `refresh_reflects_post_scan_transition_to_ready`
+        // (Unknown -> Ready). Here we cover Unknown -> NotReady, which is
+        // the shape a lazy-index provider would use to say "scan tried
+        // and confirmed there's no data". `drop_not_ready_after_refresh`
+        // then removes the candidate before `OneOfExec::try_new` invokes
+        // the cost function, preserving the invariant that NotReady never
+        // reaches cost policy. (Ready -> NotReady is deliberately not
+        // supported — see the fast-path doc on refresh_candidate_readiness.)
         register_materialized::<MockMv>();
         let ctx = SessionContext::new();
-        let mv = MockMv::new("target_t", RewriteReadiness::Ready);
+        let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
         ctx.register_table("mv_regressed", Arc::clone(&mv) as Arc<dyn TableProvider>)
             .expect("register mv_regressed");
         let state = ctx.state();
@@ -2029,9 +2099,9 @@ mod tests_physical_time_readiness_refresh {
             state.config().options().catalog.default_schema,
         );
 
-        let context = one_mv_context(&fq_name, RewriteReadiness::Ready);
+        let context = one_mv_context(&fq_name, RewriteReadiness::Unknown);
 
-        // Provider changes its mind after LP rewrite.
+        // Simulated scan concluded that the MV is unpopulated.
         mv.set_readiness(RewriteReadiness::NotReady);
 
         let refreshed = refresh_candidate_readiness(context, &state).await;
@@ -2290,15 +2360,16 @@ mod tests_physical_time_readiness_refresh {
 
     #[tokio::test]
     async fn plan_extension_short_circuits_to_base_when_all_mvs_go_not_ready() {
-        // A provider that was `Ready` at LP-time can transition to
-        // `NotReady` between LP and physical planning (rare, but possible
-        // if `scan()` discovered the MV is unpopulated). `plan_extension`
-        // must filter it out and — because only Base survives — return the
-        // base physical plan directly instead of wrapping it in an
-        // otherwise-useless single-branch OneOfExec.
+        // Provider was `Unknown` at LP-time (cold lazy). `scan()` runs
+        // during physical planning and discovers the MV is unpopulated,
+        // so the provider now reports `NotReady`. `plan_extension` must
+        // refresh (Unknown triggers the refresh path), pick up the new
+        // `NotReady`, filter out the MV, and — because only Base survives
+        // — return the base physical plan directly instead of wrapping
+        // it in an otherwise-useless single-branch OneOfExec.
         register_materialized::<MockMv>();
         let ctx = SessionContext::new();
-        let mv = MockMv::new("target_t", RewriteReadiness::Ready);
+        let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
         ctx.register_table("mv_regressed", Arc::clone(&mv) as Arc<dyn TableProvider>)
             .expect("register mv_regressed");
         let state = ctx.state();
@@ -2319,7 +2390,7 @@ mod tests_physical_time_readiness_refresh {
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
                     table_ref: fq_name,
-                    readiness: RewriteReadiness::Ready,
+                    readiness: RewriteReadiness::Unknown,
                 },
             ]),
         );

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -64,75 +64,18 @@ use datafusion_physical_expr::OrderingRequirements;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 
-use crate::materialized::{cast_to_materialized, RewriteReadiness};
+use crate::materialized::cast_to_materialized;
 
 use super::normal_form::SpjNormalForm;
 use super::QueryRewriteOptions;
 
-/// Per-branch metadata inside a `OneOf` / `OneOfExec`. One variant per branch,
-/// aligned by index with the containing `branches` / `candidates` vector.
-///
-/// Lifecycle judgement (populated / unpopulated / stale / ...) is made in two
-/// stages via [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness):
-///
-/// 1. At LP-rewrite time, [`ViewMatcher`] drops `NotReady` providers and
-///    admits `Ready` + `Unknown` as candidates.
-/// 2. At physical-planning time, once DataFusion has invoked each provider's
-///    `scan()` (giving lazy indexes a chance to warm),
-///    [`ViewExploitationPlanner`] re-consults `rewrite_readiness()` and
-///    updates the metadata to the current value; providers that transitioned
-///    to `NotReady` between the two stages are dropped here.
-///
-/// So any `Materialized` variant that reaches the cost function reflects the
-/// **post-scan** readiness, and `NotReady` is guaranteed to have been filtered
-/// (upstream or downstream of scan) before the cost function runs. `Ready`
-/// and `Unknown` remain distinguishable so cost policy for the two can diverge
-/// (typically: trust `Ready` as safe to route, and fall back to a conservative
-/// estimate for `Unknown`).
-///
-/// The invariant enforced at construction inside [`ViewMatcher`]:
-///
-/// * Index 0 is always [`CandidateMetadata::Base`] — the query's original LP,
-///   with no MV rewrite applied. `OneOf::schema()` reads `branches[0].schema()`
-///   and therefore always exposes the query's schema (not an MV's).
-/// * Indices 1..N are [`CandidateMetadata::Materialized`] entries, sorted
-///   deterministically by `table_ref`. Sorting on the MV's registered
-///   `TableReference` (rather than on the branch LP) keeps the order stable
-///   under downstream LP transformations that happen between LP rewrite and
-///   physical planning — identity projection elimination, always-true filter
-///   folding, etc. change the LP but never the MV's registered name, so the
-///   alignment between this metadata and the physical candidate the cost
-///   function receives survives every optimizer pass.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash)]
-pub enum CandidateMetadata {
-    /// The query's original branch (index 0 in every OneOf).
-    Base,
-    /// A materialized-view rewrite of the query. Only MVs that reported
-    /// `Ready` or `Unknown` readiness reach this state; `NotReady` MVs
-    /// are filtered upstream by [`ViewMatcher`]. Cost functions consult
-    /// the `readiness` field to distinguish the two cases: `Unknown`
-    /// (the trait default returned by [`RewriteReadiness`]) must not be
-    /// silently treated as `Ready`, since that would regress providers
-    /// that haven't declared a lifecycle.
-    Materialized {
-        /// Registered `TableReference` of the source MV. Stored directly
-        /// rather than as `.to_string()` so identifiers with dots or
-        /// quoting round-trip losslessly through the physical-time
-        /// catalog resolution. Stable across LP transformations; safe to
-        /// use as a sort key.
-        table_ref: TableReference,
-        /// Provider readiness as observed at physical-planning time — i.e.
-        /// after DataFusion has invoked `TableProvider::scan()` on this
-        /// branch. Set once at LP rewrite from the provider's initial
-        /// report and refreshed from the same provider inside
-        /// [`ViewExploitationPlanner::plan_extension`] so lazy-index
-        /// providers surface their warmed-up value. Downstream cost
-        /// functions branch on this to implement their `Unknown` policy
-        /// (e.g. fall back to the base scan cost rather than trust an
-        /// EmptyExec as predicate-pruned).
-        readiness: RewriteReadiness,
-    },
-}
+// Bring readiness types in for use inside this module AND re-export
+// them for backward compatibility. Callers that used to import from
+// `crate::rewrite::exploitation` (the pre-move location) keep working;
+// the canonical home is now `crate::rewrite::readiness`.
+pub use super::readiness::{
+    readiness_from_plan, CandidateMetadata, ReadinessAnnotatedExec, RewriteReadiness,
+};
 
 /// Logical rewrite metadata propagated alongside equivalent candidate plans.
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Hash)]
@@ -1044,129 +987,6 @@ impl PhysicalOptimizerRule for PruneCandidates {
     }
 }
 
-/// Wraps the `ExecutionPlan` returned by a `Materialized` provider's
-/// `scan()` together with the readiness value captured at scan time.
-///
-/// Providers use this to close the race between "which snapshot did
-/// scan read from" and "what does `rewrite_readiness()` return now".
-/// Sampling `rewrite_readiness()` again after `scan()` has returned is
-/// racy — a concurrent snapshot swap can publish new state between the
-/// two calls, letting an `EmptyExec` from the old snapshot be labelled
-/// with readiness from the new one. If the provider computes both
-/// atomically (from the same state Arc, under the same read lock, etc.)
-/// and wraps the returned plan with `ReadinessAnnotatedExec`, the
-/// physical-time refresh in `ViewExploitationPlanner::plan_extension`
-/// reads the annotated value verbatim instead of re-sampling.
-///
-/// The wrapper is transparent: all `ExecutionPlan` methods delegate to
-/// the inner plan, so downstream operators see the same shape as if the
-/// provider returned `inner` directly.
-///
-/// Providers that don't wrap fall back to the pre-existing (racy)
-/// sampling path in the refresh, which remains supported for backward
-/// compatibility.
-#[derive(Debug)]
-pub struct ReadinessAnnotatedExec {
-    inner: Arc<dyn ExecutionPlan>,
-    readiness: RewriteReadiness,
-    properties: Arc<PlanProperties>,
-}
-
-impl ReadinessAnnotatedExec {
-    /// Wrap `inner` with the readiness captured atomically at scan time.
-    pub fn new(inner: Arc<dyn ExecutionPlan>, readiness: RewriteReadiness) -> Self {
-        let properties = Arc::clone(inner.properties());
-        Self {
-            inner,
-            readiness,
-            properties,
-        }
-    }
-
-    /// Readiness captured at the moment the provider produced `inner`.
-    pub fn readiness(&self) -> RewriteReadiness {
-        self.readiness
-    }
-
-    /// The wrapped plan.
-    pub fn inner(&self) -> &Arc<dyn ExecutionPlan> {
-        &self.inner
-    }
-}
-
-impl DisplayAs for ReadinessAnnotatedExec {
-    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match t {
-            DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                write!(f, "ReadinessAnnotatedExec: readiness={:?}", self.readiness)
-            }
-            DisplayFormatType::TreeRender => Ok(()),
-        }
-    }
-}
-
-impl ExecutionPlan for ReadinessAnnotatedExec {
-    fn name(&self) -> &str {
-        "ReadinessAnnotatedExec"
-    }
-
-    fn properties(&self) -> &Arc<PlanProperties> {
-        &self.properties
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.inner]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        if children.len() != 1 {
-            return Err(DataFusionError::Plan(format!(
-                "ReadinessAnnotatedExec expects exactly one child, got {}",
-                children.len()
-            )));
-        }
-        Ok(Arc::new(ReadinessAnnotatedExec::new(
-            children.into_iter().next().unwrap(),
-            self.readiness,
-        )))
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<TaskContext>,
-    ) -> Result<SendableRecordBatchStream> {
-        self.inner.execute(partition, context)
-    }
-
-    fn partition_statistics(
-        &self,
-        partition: Option<usize>,
-    ) -> Result<Arc<datafusion_common::Statistics>> {
-        self.inner.partition_statistics(partition)
-    }
-}
-
-/// Depth-first search for the nearest `ReadinessAnnotatedExec` in a
-/// physical plan tree. Returns its readiness value, or `None` if the
-/// tree doesn't contain one (e.g. the provider hasn't opted in). Used
-/// by the physical-time refresh to prefer atomically-captured readiness
-/// over racy re-sampling.
-pub fn readiness_from_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<RewriteReadiness> {
-    if let Some(annotated) = plan.downcast_ref::<ReadinessAnnotatedExec>() {
-        return Some(annotated.readiness());
-    }
-    for child in plan.children() {
-        if let Some(readiness) = readiness_from_plan(child) {
-            return Some(readiness);
-        }
-    }
-    None
-}
-
 /// Compare two Arrow schemas ignoring field nullability.
 fn schemas_equal_ignoring_nullability(a: &arrow_schema::Schema, b: &arrow_schema::Schema) -> bool {
     a.fields().len() == b.fields().len()
@@ -2076,7 +1896,8 @@ mod tests_view_matcher_readiness_filter {
 mod tests_physical_time_readiness_refresh {
     use super::tests_view_matcher_readiness_filter::*;
     use super::*;
-    use crate::materialized::{register_materialized, RewriteReadiness};
+    use crate::materialized::register_materialized;
+    use crate::rewrite::readiness::ReadinessAnnotatedExec;
     use datafusion::execution::context::SessionContext;
     use datafusion_expr::LogicalPlanBuilder;
     use std::sync::Arc;

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -72,15 +72,23 @@ use super::QueryRewriteOptions;
 /// Per-branch metadata inside a `OneOf` / `OneOfExec`. One variant per branch,
 /// aligned by index with the containing `branches` / `candidates` vector.
 ///
-/// Lifecycle judgement (populated / unpopulated / stale / ...) is made upstream
-/// by [`ViewMatcher`] via
-/// [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness):
-/// only `NotReady` MVs are dropped from the candidate set. `Ready` and
-/// `Unknown` both reach the cost function, and the raw readiness reported by
-/// the provider is preserved in [`CandidateMetadata::Materialized::readiness`]
-/// so cost policy for the two cases can diverge (typically:
-/// trust `Ready` as safe to route, and fall back to a conservative estimate
-/// for `Unknown`).
+/// Lifecycle judgement (populated / unpopulated / stale / ...) is made in two
+/// stages via [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness):
+///
+/// 1. At LP-rewrite time, [`ViewMatcher`] drops `NotReady` providers and
+///    admits `Ready` + `Unknown` as candidates.
+/// 2. At physical-planning time, once DataFusion has invoked each provider's
+///    `scan()` (giving lazy indexes a chance to warm),
+///    [`ViewExploitationPlanner`] re-consults `rewrite_readiness()` and
+///    updates the metadata to the current value; providers that transitioned
+///    to `NotReady` between the two stages are dropped here.
+///
+/// So any `Materialized` variant that reaches the cost function reflects the
+/// **post-scan** readiness, and `NotReady` is guaranteed to have been filtered
+/// (upstream or downstream of scan) before the cost function runs. `Ready`
+/// and `Unknown` remain distinguishable so cost policy for the two can diverge
+/// (typically: trust `Ready` as safe to route, and fall back to a conservative
+/// estimate for `Unknown`).
 ///
 /// The invariant enforced at construction inside [`ViewMatcher`]:
 ///
@@ -110,11 +118,15 @@ pub enum CandidateMetadata {
         /// Registered `TableReference` of the source MV. Stable across
         /// LP transformations; safe to use as a sort key.
         table_ref: String,
-        /// Readiness reported by the provider at LP rewrite time.
-        /// Preserved verbatim so downstream cost functions can implement
-        /// their own policy for the `Unknown` case (e.g. fall back to the
-        /// base scan cost rather than trust an EmptyExec as
-        /// predicate-pruned).
+        /// Provider readiness as observed at physical-planning time — i.e.
+        /// after DataFusion has invoked `TableProvider::scan()` on this
+        /// branch. Set once at LP rewrite from the provider's initial
+        /// report and refreshed from the same provider inside
+        /// [`ViewExploitationPlanner::plan_extension`] so lazy-index
+        /// providers surface their warmed-up value. Downstream cost
+        /// functions branch on this to implement their `Unknown` policy
+        /// (e.g. fall back to the base scan cost rather than trust an
+        /// EmptyExec as predicate-pruned).
         readiness: RewriteReadiness,
     },
 }
@@ -504,7 +516,7 @@ impl ExtensionPlanner for ViewExploitationPlanner {
         node: &dyn UserDefinedLogicalNode,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        _session_state: &SessionState,
+        session_state: &SessionState,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         let Some(one_of) = node.as_any().downcast_ref::<OneOf>() else {
             return Ok(None);
@@ -539,12 +551,168 @@ impl ExtensionPlanner for ViewExploitationPlanner {
             ));
         }
 
+        // Physical-time readiness resolution. By the time this planner runs,
+        // DataFusion has already planned each branch into `physical_inputs`,
+        // which means it has already invoked `TableProvider::scan()` on every
+        // candidate MV. For providers whose readiness depends on scan-time
+        // side effects (e.g. a lazy-index provider that only loads its index
+        // on first `scan()`), the readiness reported at LP-rewrite time is
+        // stale by now — re-consulting the provider here gives the definitive
+        // value the cost function should see. See PR #55 review discussion for
+        // the lazy-index cold-start scenario this addresses.
+        let refreshed_context =
+            refresh_candidate_readiness(one_of.rewrite_context().clone(), session_state).await;
+
+        // Enforce the invariant documented on `CandidateMetadata`: NotReady
+        // never reaches the cost function. A provider can transition to
+        // NotReady between LP rewrite and physical planning (rare, but
+        // possible if scan detected an unpopulated state), so this filter is
+        // the post-scan analogue of `f_down`'s upstream drop. Metadata and
+        // `physical_inputs` are filtered in lockstep to preserve the
+        // by-index alignment cost functions rely on.
+        let (kept_inputs, kept_candidates) =
+            drop_not_ready_after_refresh(physical_inputs, refreshed_context.candidates());
+
+        // If the filter left only the Base branch we can skip the OneOfExec
+        // wrapper entirely and just return the base physical plan — nothing
+        // for the cost function to choose between.
+        if kept_candidates.len() == 1 && matches!(kept_candidates[0], CandidateMetadata::Base) {
+            return Ok(Some(Arc::clone(&kept_inputs[0])));
+        }
+
+        let filtered_context = RewriteContext::new(refreshed_context.root_table_refs().to_vec())
+            .with_candidates(kept_candidates);
+
         Ok(Some(Arc::new(OneOfExec::try_new(
-            physical_inputs.to_vec(),
+            kept_inputs,
             None,
             Arc::clone(&self.cost),
-            one_of.rewrite_context().clone(),
+            filtered_context,
         )?)))
+    }
+}
+
+/// Pair-wise filter that drops every `Materialized` candidate whose
+/// refreshed readiness is `NotReady`, along with its aligned entry in
+/// `physical_inputs`. Base is never filtered.
+///
+/// If `candidates` is empty (an older callsite constructed the `OneOf`
+/// without per-branch metadata) or is not aligned with `physical_inputs`,
+/// the inputs are passed through unchanged — this filter is opt-in on
+/// having metadata; callsites without it keep their original behaviour.
+fn drop_not_ready_after_refresh(
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
+    candidates: &[CandidateMetadata],
+) -> (Vec<Arc<dyn ExecutionPlan>>, Vec<CandidateMetadata>) {
+    if candidates.len() != physical_inputs.len() {
+        return (physical_inputs.to_vec(), candidates.to_vec());
+    }
+    let mut kept_inputs = Vec::with_capacity(physical_inputs.len());
+    let mut kept_candidates = Vec::with_capacity(candidates.len());
+    for (input, cand) in physical_inputs.iter().zip(candidates.iter()) {
+        let drop = matches!(
+            cand,
+            CandidateMetadata::Materialized {
+                readiness: RewriteReadiness::NotReady,
+                ..
+            }
+        );
+        if drop {
+            continue;
+        }
+        kept_inputs.push(Arc::clone(input));
+        kept_candidates.push(cand.clone());
+    }
+    (kept_inputs, kept_candidates)
+}
+
+/// Re-consult every `Materialized` candidate's `rewrite_readiness()` and
+/// return a `RewriteContext` whose metadata reflects the current values.
+///
+/// Called from `ViewExploitationPlanner::plan_extension` once
+/// physical inputs have been planned (i.e. after `TableProvider::scan()`
+/// has run on every candidate branch). Providers whose readiness only
+/// becomes definite after scan initialization (lazy indexes, warmup jobs,
+/// snapshot swaps that happen inside `scan`) surface their new value here
+/// so the cost function sees the definitive readiness rather than the
+/// stale LP-time snapshot.
+///
+/// Lookup failures (table not found in the catalog, provider is no longer a
+/// `Materialized`, `cast_to_materialized` error) fall back to the LP-time
+/// value — the goal is to be at least as accurate as the previous value,
+/// never less.
+async fn refresh_candidate_readiness(
+    context: RewriteContext,
+    session_state: &SessionState,
+) -> RewriteContext {
+    let catalog_list = session_state.catalog_list();
+    let default_catalog = &session_state.config().options().catalog.default_catalog;
+    let default_schema = &session_state.config().options().catalog.default_schema;
+
+    let refreshed: Vec<CandidateMetadata> =
+        futures::future::join_all(context.candidates().iter().map(|c| async move {
+            match c {
+                CandidateMetadata::Base => CandidateMetadata::Base,
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } => {
+                    let new_readiness = resolve_current_readiness(
+                        catalog_list.as_ref(),
+                        default_catalog,
+                        default_schema,
+                        table_ref,
+                    )
+                    .await
+                    .unwrap_or(*readiness);
+                    CandidateMetadata::Materialized {
+                        table_ref: table_ref.clone(),
+                        readiness: new_readiness,
+                    }
+                }
+            }
+        }))
+        .await;
+
+    context.with_candidates(refreshed)
+}
+
+/// Resolve `table_ref` through the catalog list and re-consult the
+/// provider's `rewrite_readiness()`. Returns `None` on any lookup failure
+/// so the caller can fall back to the LP-time value.
+async fn resolve_current_readiness(
+    catalog_list: &dyn datafusion::catalog::CatalogProviderList,
+    default_catalog: &str,
+    default_schema: &str,
+    table_ref: &str,
+) -> Option<RewriteReadiness> {
+    // `table_ref` is the `.to_string()` of a `TableReference`, which for a
+    // `Full` variant renders as "catalog.schema.table". `TableReference::from`
+    // treats any &str as a `Bare` ref, so we need `parse_str` to split dotted
+    // names back into their component parts before catalog resolution.
+    let resolved = TableReference::parse_str(table_ref).resolve(default_catalog, default_schema);
+    let catalog = catalog_list.catalog(resolved.catalog.as_ref())?;
+    let schema = catalog.schema(resolved.schema.as_ref())?;
+    let table = match schema.table(resolved.table.as_ref()).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            log::trace!("refresh_candidate_readiness: no table {table_ref} in catalog");
+            return None;
+        }
+        Err(e) => {
+            log::warn!("refresh_candidate_readiness: catalog lookup failed for {table_ref}: {e}");
+            return None;
+        }
+    };
+    match cast_to_materialized(table.as_ref()) {
+        Ok(Some(mv)) => Some(mv.rewrite_readiness()),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!(
+                "refresh_candidate_readiness: cast_to_materialized failed for {table_ref}: {e}"
+            );
+            None
+        }
     }
 }
 
@@ -1222,9 +1390,6 @@ mod tests_rewrite_context {
         // cost function is *also* reading — a subtle coupling. Build a
         // mixed-readiness set and check that the lexicographic table_ref
         // order is preserved: mv_a (Unknown), mv_b (Ready), mv_c (Unknown).
-        let base = LogicalPlanBuilder::empty(false)
-            .build()
-            .expect("empty base plan");
         let mv_a_lp = LogicalPlanBuilder::empty(true).build().expect("mv_a plan");
         let mv_b_lp = LogicalPlanBuilder::empty(true).build().expect("mv_b plan");
         let mv_c_lp = LogicalPlanBuilder::empty(true).build().expect("mv_c plan");
@@ -1278,8 +1443,6 @@ mod tests_rewrite_context {
                 readiness: RewriteReadiness::Unknown,
             }
         );
-        // Silence dead-code warning on the surrounding `base` binding.
-        let _ = base;
     }
 
     #[test]
@@ -1367,26 +1530,25 @@ mod tests_view_matcher_readiness_filter {
     use datafusion_expr::builder::LogicalTableSource;
     use datafusion_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
     use std::collections::HashMap;
-    use std::sync::atomic::{AtomicU8, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     /// Mock Materialized provider with a caller-selectable readiness value.
     /// The `query` is a trivial `TableScan(source_table)` so the rewriter's
     /// `SpjNormalForm` handling can trivially match a base LP against it.
     ///
-    /// `readiness` is stored in an `AtomicU8` so tests that need to simulate
-    /// lifecycle transitions (e.g. a cold lazy index reporting `Unknown`
-    /// during the first rewrite pass and `Ready` after the scan initialises
-    /// it) can flip the value without rebuilding the whole `ViewMatcher`.
+    /// `readiness` uses interior mutability so tests can simulate lifecycle
+    /// transitions (e.g. a cold lazy index reporting `Unknown` during the
+    /// first rewrite pass and `Ready` after the scan initialises it) without
+    /// rebuilding the whole `ViewMatcher`.
     #[derive(Debug)]
-    struct MockMv {
+    pub(super) struct MockMv {
         source_table: String,
         query: LogicalPlan,
-        readiness: AtomicU8,
+        readiness: Mutex<RewriteReadiness>,
     }
 
     impl MockMv {
-        fn new(source_table: &str, readiness: RewriteReadiness) -> Arc<Self> {
+        pub(super) fn new(source_table: &str, readiness: RewriteReadiness) -> Arc<Self> {
             let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
             let source = Arc::new(LogicalTableSource::new(schema));
             let query = LogicalPlanBuilder::scan(source_table, source, None)
@@ -1396,29 +1558,12 @@ mod tests_view_matcher_readiness_filter {
             Arc::new(Self {
                 source_table: source_table.to_string(),
                 query,
-                readiness: AtomicU8::new(encode_readiness(readiness)),
+                readiness: Mutex::new(readiness),
             })
         }
 
-        fn set_readiness(&self, readiness: RewriteReadiness) {
-            self.readiness
-                .store(encode_readiness(readiness), Ordering::SeqCst);
-        }
-    }
-
-    fn encode_readiness(r: RewriteReadiness) -> u8 {
-        match r {
-            RewriteReadiness::Ready => 0,
-            RewriteReadiness::NotReady => 1,
-            RewriteReadiness::Unknown => 2,
-        }
-    }
-
-    fn decode_readiness(v: u8) -> RewriteReadiness {
-        match v {
-            0 => RewriteReadiness::Ready,
-            1 => RewriteReadiness::NotReady,
-            _ => RewriteReadiness::Unknown,
+        pub(super) fn set_readiness(&self, readiness: RewriteReadiness) {
+            *self.readiness.lock().expect("readiness mutex") = readiness;
         }
     }
 
@@ -1437,7 +1582,18 @@ mod tests_view_matcher_readiness_filter {
             _filters: &[Expr],
             _limit: Option<usize>,
         ) -> Result<Arc<dyn ExecutionPlan>> {
-            unimplemented!("MockMv::scan is not exercised by these tests")
+            // Mimic a lazy-index provider whose `scan()` transitions the
+            // provider from cold (`Unknown`) to `Ready` because it has just
+            // initialised the index. Only promotes; does not overwrite an
+            // existing `Ready` and never toggles `NotReady` (which stays
+            // `NotReady` — a provider that reported unpopulated shouldn't
+            // silently become populated by being scanned).
+            if self.rewrite_readiness() == RewriteReadiness::Unknown {
+                self.set_readiness(RewriteReadiness::Ready);
+            }
+            Ok(Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                self.schema(),
+            )))
         }
     }
 
@@ -1460,7 +1616,7 @@ mod tests_view_matcher_readiness_filter {
             self.query.clone()
         }
         fn rewrite_readiness(&self) -> RewriteReadiness {
-            decode_readiness(self.readiness.load(Ordering::SeqCst))
+            *self.readiness.lock().expect("readiness mutex")
         }
     }
 
@@ -1668,17 +1824,33 @@ mod tests_view_matcher_readiness_filter {
     }
 
     #[test]
-    fn f_down_admits_unknown_provider_across_lifecycle_transition() {
-        // Scenario: a provider that uses a lazy-loaded index reports
-        // `Unknown` on its first rewrite pass (index cold, not yet queried)
-        // and `Ready` once the scan has initialised it. Reporting `NotReady`
-        // in the cold phase would filter the MV out here, the scan would
-        // never plan, and the index would stay cold forever — a rewrite-time
-        // deadlock. The recommended provider policy is therefore to report
-        // `Unknown` in the cold phase; this test locks in that (a) `f_down`
-        // admits `Unknown`, and (b) once the provider transitions to `Ready`
-        // the next rewrite reports the new readiness verbatim, so the cost
-        // function can pick the more aggressive policy for it.
+    fn f_down_reflects_provider_readiness_on_each_rewrite() {
+        // What this test proves (a metadata-channel property):
+        // 1. `f_down` re-consults the provider's `rewrite_readiness()` on
+        //    every rewrite pass rather than caching the first result, and
+        // 2. propagates the current value verbatim into
+        //    `CandidateMetadata::Materialized::readiness`.
+        //
+        // Motivation (see PR #55 review by @xudong963): a provider that
+        // uses a lazy-loaded index can report `Unknown` while the index is
+        // cold and `Ready` once something warms it. If the rewriter cached
+        // the cold `Unknown` reading, a provider that later transitions to
+        // `Ready` would never surface that fact to the cost function, and
+        // policies keyed on `Ready` would never activate.
+        //
+        // What this test does *not* prove:
+        // * That the transition is triggered by a real scan. Here it is
+        //   flipped explicitly via `set_readiness`. In production the
+        //   trigger would be a lazy-index provider's `scan()` (e.g. atlas's
+        //   `FileScanTable::scan()` calling `Index::query()`). Full
+        //   end-to-end coverage of that path — including the
+        //   `lazy_index = true` cold-start behaviour @xudong963 asked
+        //   about — belongs in the downstream provider's own tests, not
+        //   here.
+        // * That a provider reporting `Unknown` in the cold phase actually
+        //   avoids the "scan never plans, index stays cold" deadlock. That
+        //   depends on the cost function's policy for `Unknown` candidates
+        //   (this crate does not ship one).
         crate::materialized::register_materialized::<MockMv>();
         let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
         let form = SpjNormalForm::new(&mv.query).expect("valid SPJ");
@@ -1690,11 +1862,10 @@ mod tests_view_matcher_readiness_filter {
         );
         let matcher = ViewMatcher::from_mv_plans_for_test(plans);
 
-        // First pass: cold => Unknown, must survive the filter with
-        // `readiness = Unknown` propagated into the metadata.
+        // First rewrite: provider is reporting `Unknown` and must be
+        // admitted with that value in the metadata.
         let cold = rewrite_scan_lp(&matcher, "target_t");
-        let cold_meta = candidate_metadata(&cold);
-        let cold_readiness = cold_meta
+        let cold_readiness = candidate_metadata(&cold)
             .iter()
             .find_map(|c| match c {
                 CandidateMetadata::Materialized {
@@ -1703,14 +1874,20 @@ mod tests_view_matcher_readiness_filter {
                 } if table_ref == "mv_cold_lazy" => Some(*readiness),
                 _ => None,
             })
-            .expect("cold-lazy MV must be admitted as Unknown, not filtered");
+            .expect("Unknown provider must be admitted as a candidate");
         assert_eq!(cold_readiness, RewriteReadiness::Unknown);
 
-        // Second pass after the (mock) scan has warmed the index.
+        // Simulate the transition a lazy-index provider would perform when
+        // its scan warms the index. We flip the value directly here; the
+        // property under test is that the *next* rewrite observes the new
+        // value, not how the transition itself is triggered.
         mv.set_readiness(RewriteReadiness::Ready);
+
+        // Second rewrite: `f_down` must have re-consulted the provider
+        // (no caching) and the new readiness must be visible verbatim to
+        // downstream cost functions.
         let warm = rewrite_scan_lp(&matcher, "target_t");
-        let warm_meta = candidate_metadata(&warm);
-        let warm_readiness = warm_meta
+        let warm_readiness = candidate_metadata(&warm)
             .iter()
             .find_map(|c| match c {
                 CandidateMetadata::Materialized {
@@ -1719,7 +1896,451 @@ mod tests_view_matcher_readiness_filter {
                 } if table_ref == "mv_cold_lazy" => Some(*readiness),
                 _ => None,
             })
-            .expect("warm MV must still be a candidate");
+            .expect("provider that transitions to Ready must remain a candidate");
         assert_eq!(warm_readiness, RewriteReadiness::Ready);
+    }
+}
+
+/// Coverage for the physical-time readiness refresh that runs from
+/// `ViewExploitationPlanner::plan_extension` once DataFusion has planned
+/// each candidate branch into a physical tree (which invokes each
+/// provider's `scan()`, giving lazy indexes a chance to warm).
+#[cfg(test)]
+mod tests_physical_time_readiness_refresh {
+    use super::tests_view_matcher_readiness_filter::*;
+    use super::*;
+    use crate::materialized::{register_materialized, RewriteReadiness};
+    use datafusion::execution::context::SessionContext;
+    use datafusion_expr::LogicalPlanBuilder;
+    use std::sync::Arc;
+
+    /// Pull the readiness carried by the `Materialized { table_ref: name, .. }`
+    /// entry out of a `RewriteContext`, panicking if it isn't present.
+    fn readiness_for(context: &RewriteContext, name: &str) -> RewriteReadiness {
+        context
+            .candidates()
+            .iter()
+            .find_map(|c| match c {
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } if table_ref.ends_with(name) => Some(*readiness),
+                _ => None,
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected Materialized candidate for '{name}' in {:?}",
+                    context.candidates()
+                )
+            })
+    }
+
+    /// Build a `RewriteContext` shaped like what `f_down` would produce: a
+    /// Base branch plus one `Materialized` branch pointing at the
+    /// fully-qualified `table_ref`.
+    fn one_mv_context(table_ref: &str, lp_time_readiness: RewriteReadiness) -> RewriteContext {
+        RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
+            CandidateMetadata::Base,
+            CandidateMetadata::Materialized {
+                table_ref: table_ref.to_string(),
+                readiness: lp_time_readiness,
+            },
+        ])
+    }
+
+    #[tokio::test]
+    async fn refresh_reflects_post_scan_transition_to_ready() {
+        // Simulate the lazy-index cold-start scenario end-to-end at the
+        // `RewriteContext` layer. Provider starts Unknown, its `scan()` is
+        // invoked (mimicking what physical planning would do), the scan
+        // impl promotes readiness to Ready, and the refresh helper picks
+        // up the new value from the same catalog handle.
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
+        ctx.register_table("mv_lazy", Arc::clone(&mv) as Arc<dyn TableProvider>)
+            .expect("register mv_lazy");
+        let state = ctx.state();
+        // At registration time atlas would key the metadata by the fully
+        // qualified name the catalog uses; do the same here.
+        let fq_name = format!(
+            "{}.{}.mv_lazy",
+            state.config().options().catalog.default_catalog,
+            state.config().options().catalog.default_schema,
+        );
+
+        // LP-time snapshot: cold.
+        let context = one_mv_context(&fq_name, RewriteReadiness::Unknown);
+
+        // Physical planning would have called scan() on the MV branch by
+        // now; call it directly to simulate that side effect.
+        let session_for_scan = state.clone();
+        mv.scan(&session_for_scan, None, &[], None)
+            .await
+            .expect("scan flips readiness");
+
+        // Now refresh — should observe Ready.
+        let refreshed = refresh_candidate_readiness(context, &state).await;
+        assert_eq!(
+            readiness_for(&refreshed, "mv_lazy"),
+            RewriteReadiness::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_falls_back_to_lp_time_value_when_provider_missing() {
+        // Provider is not registered under the recorded `table_ref`. The
+        // helper must return the caller's LP-time value verbatim rather
+        // than defaulting to Unknown, so a transient catalog hiccup can't
+        // silently downgrade a previously-observed Ready to Unknown.
+        let ctx = SessionContext::new();
+        let context = one_mv_context("datafusion.public.does_not_exist", RewriteReadiness::Ready);
+
+        let refreshed = refresh_candidate_readiness(context, &ctx.state()).await;
+        assert_eq!(
+            readiness_for(&refreshed, "does_not_exist"),
+            RewriteReadiness::Ready,
+            "missing catalog entry must not overwrite LP-time readiness"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_reflects_transition_to_not_ready() {
+        // If a provider observed as `Ready` at LP-time transitions to
+        // `NotReady` between LP rewrite and physical planning (rare, but
+        // possible if scan itself detects unpopulated state), refresh
+        // must surface that so the cost function can penalize it.
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::Ready);
+        ctx.register_table("mv_regressed", Arc::clone(&mv) as Arc<dyn TableProvider>)
+            .expect("register mv_regressed");
+        let state = ctx.state();
+        let fq_name = format!(
+            "{}.{}.mv_regressed",
+            state.config().options().catalog.default_catalog,
+            state.config().options().catalog.default_schema,
+        );
+
+        let context = one_mv_context(&fq_name, RewriteReadiness::Ready);
+
+        // Provider changes its mind after LP rewrite.
+        mv.set_readiness(RewriteReadiness::NotReady);
+
+        let refreshed = refresh_candidate_readiness(context, &state).await;
+        assert_eq!(
+            readiness_for(&refreshed, "mv_regressed"),
+            RewriteReadiness::NotReady
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_leaves_base_variant_untouched() {
+        // `CandidateMetadata::Base` has no provider; refresh must skip it.
+        let ctx = SessionContext::new();
+        let context = RewriteContext::new(vec!["target_t".to_string()])
+            .with_candidates(vec![CandidateMetadata::Base]);
+
+        let refreshed = refresh_candidate_readiness(context, &ctx.state()).await;
+        assert_eq!(refreshed.candidates().len(), 1);
+        assert!(matches!(refreshed.candidates()[0], CandidateMetadata::Base));
+    }
+
+    #[test]
+    fn drop_not_ready_filter_keeps_ready_and_unknown_and_base() {
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let make = || Arc::new(EmptyExec::new(Arc::clone(&schema))) as Arc<dyn ExecutionPlan>;
+        let physical_inputs = vec![make(), make(), make(), make()];
+        let candidates = vec![
+            CandidateMetadata::Base,
+            CandidateMetadata::Materialized {
+                table_ref: "a".to_string(),
+                readiness: RewriteReadiness::Ready,
+            },
+            CandidateMetadata::Materialized {
+                table_ref: "b".to_string(),
+                readiness: RewriteReadiness::NotReady,
+            },
+            CandidateMetadata::Materialized {
+                table_ref: "c".to_string(),
+                readiness: RewriteReadiness::Unknown,
+            },
+        ];
+
+        let (kept_inputs, kept_candidates) =
+            drop_not_ready_after_refresh(&physical_inputs, &candidates);
+        assert_eq!(kept_inputs.len(), 3, "NotReady branch must be dropped");
+        assert_eq!(kept_candidates.len(), 3);
+        assert!(matches!(kept_candidates[0], CandidateMetadata::Base));
+        assert!(matches!(
+            &kept_candidates[1],
+            CandidateMetadata::Materialized { table_ref, readiness: RewriteReadiness::Ready }
+                if table_ref == "a"
+        ));
+        assert!(matches!(
+            &kept_candidates[2],
+            CandidateMetadata::Materialized { table_ref, readiness: RewriteReadiness::Unknown }
+                if table_ref == "c"
+        ));
+    }
+
+    #[test]
+    fn drop_not_ready_filter_passes_through_when_metadata_missing() {
+        // Older callsites construct `OneOf` without per-branch metadata.
+        // The filter must not corrupt those: with a length mismatch, hand
+        // the inputs back unchanged so downstream keeps working.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let make = || Arc::new(EmptyExec::new(Arc::clone(&schema))) as Arc<dyn ExecutionPlan>;
+        let physical_inputs = vec![make(), make()];
+        let candidates: Vec<CandidateMetadata> = Vec::new();
+
+        let (kept_inputs, kept_candidates) =
+            drop_not_ready_after_refresh(&physical_inputs, &candidates);
+        assert_eq!(kept_inputs.len(), 2);
+        assert!(kept_candidates.is_empty());
+    }
+
+    #[test]
+    fn drop_not_ready_filter_collapses_all_mvs_to_base_only() {
+        // If every MV branch transitions to `NotReady`, only Base survives.
+        // The `plan_extension` short-circuit uses this exact shape to skip
+        // the OneOfExec wrapper and return the base plan directly.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let make = || Arc::new(EmptyExec::new(Arc::clone(&schema))) as Arc<dyn ExecutionPlan>;
+        let physical_inputs = vec![make(), make(), make()];
+        let candidates = vec![
+            CandidateMetadata::Base,
+            CandidateMetadata::Materialized {
+                table_ref: "a".to_string(),
+                readiness: RewriteReadiness::NotReady,
+            },
+            CandidateMetadata::Materialized {
+                table_ref: "b".to_string(),
+                readiness: RewriteReadiness::NotReady,
+            },
+        ];
+
+        let (kept_inputs, kept_candidates) =
+            drop_not_ready_after_refresh(&physical_inputs, &candidates);
+        assert_eq!(kept_inputs.len(), 1);
+        assert_eq!(kept_candidates.len(), 1);
+        assert!(matches!(kept_candidates[0], CandidateMetadata::Base));
+    }
+
+    /// Bare-bones `PhysicalPlanner` for `plan_extension` end-to-end tests.
+    /// `plan_extension` never invokes the planner argument (the field is
+    /// `_planner`), so this stub can panic in every method.
+    struct StubPlanner;
+
+    #[async_trait::async_trait]
+    impl datafusion::physical_planner::PhysicalPlanner for StubPlanner {
+        async fn create_physical_plan(
+            &self,
+            _logical_plan: &LogicalPlan,
+            _session_state: &datafusion::execution::context::SessionState,
+        ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+            unimplemented!("StubPlanner::create_physical_plan not exercised")
+        }
+        fn create_physical_expr(
+            &self,
+            _expr: &datafusion_expr::Expr,
+            _input_dfschema: &datafusion_common::DFSchema,
+            _session_state: &datafusion::execution::context::SessionState,
+        ) -> datafusion_common::Result<Arc<dyn datafusion::physical_expr::PhysicalExpr>> {
+            unimplemented!("StubPlanner::create_physical_expr not exercised")
+        }
+    }
+
+    fn make_empty_exec() -> Arc<dyn ExecutionPlan> {
+        Arc::new(datafusion::physical_plan::empty::EmptyExec::new(Arc::new(
+            arrow_schema::Schema::empty(),
+        ))) as Arc<dyn ExecutionPlan>
+    }
+
+    #[tokio::test]
+    async fn plan_extension_updates_metadata_after_scan_transition() {
+        // End-to-end path through `ViewExploitationPlanner::plan_extension`:
+        // provider is Unknown at LP-time, the (mock) scan promotes it to
+        // Ready, and the returned OneOfExec's metadata reflects the
+        // post-scan value. This is the cold-lazy scenario Xudong called
+        // out, wired through the actual `plan_extension` composition of
+        // refresh + filter + OneOfExec construction.
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
+        ctx.register_table("mv_lazy", Arc::clone(&mv) as Arc<dyn TableProvider>)
+            .expect("register mv_lazy");
+        let state = ctx.state();
+
+        // Simulate the scan that physical planning would have performed:
+        // MockMv::scan promotes readiness Unknown -> Ready.
+        mv.scan(&state, None, &[], None)
+            .await
+            .expect("scan flips readiness");
+
+        let fq_name = format!(
+            "{}.{}.mv_lazy",
+            state.config().options().catalog.default_catalog,
+            state.config().options().catalog.default_schema,
+        );
+        let base_lp = LogicalPlanBuilder::empty(false).build().expect("base lp");
+        let mv_lp = LogicalPlanBuilder::empty(false).build().expect("mv lp");
+        let one_of_node = OneOf::with_rewrite_context(
+            vec![base_lp.clone(), mv_lp.clone()],
+            RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
+                CandidateMetadata::Base,
+                CandidateMetadata::Materialized {
+                    table_ref: fq_name.clone(),
+                    readiness: RewriteReadiness::Unknown,
+                },
+            ]),
+        );
+
+        let base_phys = make_empty_exec();
+        let mv_phys = make_empty_exec();
+
+        let cost_fn: CostFn = Arc::new(|ctx| ctx.into_candidate_plans().map(|_| 1.0_f64).collect());
+        let planner = ViewExploitationPlanner::new(cost_fn);
+        let stub = StubPlanner;
+
+        let result = planner
+            .plan_extension(
+                &stub,
+                &one_of_node,
+                &[&base_lp, &mv_lp],
+                &[Arc::clone(&base_phys), Arc::clone(&mv_phys)],
+                &state,
+            )
+            .await
+            .expect("plan_extension")
+            .expect("plan_extension returned Some");
+
+        let one_of_exec = result
+            .downcast_ref::<OneOfExec>()
+            .expect("result must be OneOfExec after refresh");
+        let candidates = one_of_exec.rewrite_context().candidates();
+        assert_eq!(candidates.len(), 2, "Base + refreshed Materialized");
+        assert!(matches!(candidates[0], CandidateMetadata::Base));
+        let (fetched_ref, fetched_readiness) = candidates
+            .iter()
+            .find_map(|c| match c {
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } => Some((table_ref.clone(), *readiness)),
+                _ => None,
+            })
+            .expect("expected Materialized entry");
+        assert_eq!(fetched_ref, fq_name);
+        assert_eq!(
+            fetched_readiness,
+            RewriteReadiness::Ready,
+            "post-scan refresh must have promoted Unknown -> Ready"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_extension_short_circuits_to_base_when_all_mvs_go_not_ready() {
+        // A provider that was `Ready` at LP-time can transition to
+        // `NotReady` between LP and physical planning (rare, but possible
+        // if `scan()` discovered the MV is unpopulated). `plan_extension`
+        // must filter it out and — because only Base survives — return the
+        // base physical plan directly instead of wrapping it in an
+        // otherwise-useless single-branch OneOfExec.
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::Ready);
+        ctx.register_table("mv_regressed", Arc::clone(&mv) as Arc<dyn TableProvider>)
+            .expect("register mv_regressed");
+        let state = ctx.state();
+
+        // Simulate scan discovering the MV is unusable.
+        mv.set_readiness(RewriteReadiness::NotReady);
+
+        let fq_name = format!(
+            "{}.{}.mv_regressed",
+            state.config().options().catalog.default_catalog,
+            state.config().options().catalog.default_schema,
+        );
+        let base_lp = LogicalPlanBuilder::empty(false).build().expect("base lp");
+        let mv_lp = LogicalPlanBuilder::empty(false).build().expect("mv lp");
+        let one_of_node = OneOf::with_rewrite_context(
+            vec![base_lp.clone(), mv_lp.clone()],
+            RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
+                CandidateMetadata::Base,
+                CandidateMetadata::Materialized {
+                    table_ref: fq_name,
+                    readiness: RewriteReadiness::Ready,
+                },
+            ]),
+        );
+
+        let base_phys = make_empty_exec();
+        let mv_phys = make_empty_exec();
+
+        let cost_fn: CostFn = Arc::new(|ctx| ctx.into_candidate_plans().map(|_| 1.0_f64).collect());
+        let planner = ViewExploitationPlanner::new(cost_fn);
+        let stub = StubPlanner;
+
+        let result = planner
+            .plan_extension(
+                &stub,
+                &one_of_node,
+                &[&base_lp, &mv_lp],
+                &[Arc::clone(&base_phys), Arc::clone(&mv_phys)],
+                &state,
+            )
+            .await
+            .expect("plan_extension")
+            .expect("plan_extension returned Some");
+
+        assert!(
+            result.downcast_ref::<OneOfExec>().is_none(),
+            "should short-circuit to base plan, not wrap in OneOfExec"
+        );
+        assert!(
+            Arc::ptr_eq(&result, &base_phys),
+            "short-circuit must return the base physical input verbatim"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_does_not_move_base_off_index_zero() {
+        // The alignment invariant on `CandidateMetadata` says Base sits at
+        // index 0. Refresh iterates in order and rebuilds the vector, so
+        // it should preserve position.
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv_a = MockMv::new("target_t", RewriteReadiness::Ready);
+        let mv_b = MockMv::new("target_t", RewriteReadiness::Unknown);
+        ctx.register_table("mv_a", Arc::clone(&mv_a) as Arc<dyn TableProvider>)
+            .expect("register mv_a");
+        ctx.register_table("mv_b", Arc::clone(&mv_b) as Arc<dyn TableProvider>)
+            .expect("register mv_b");
+        let state = ctx.state();
+        let default_catalog = &state.config().options().catalog.default_catalog;
+        let default_schema = &state.config().options().catalog.default_schema;
+
+        let context = RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
+            CandidateMetadata::Base,
+            CandidateMetadata::Materialized {
+                table_ref: format!("{default_catalog}.{default_schema}.mv_a"),
+                readiness: RewriteReadiness::Ready,
+            },
+            CandidateMetadata::Materialized {
+                table_ref: format!("{default_catalog}.{default_schema}.mv_b"),
+                readiness: RewriteReadiness::Unknown,
+            },
+        ]);
+
+        let refreshed = refresh_candidate_readiness(context, &state).await;
+        assert!(matches!(refreshed.candidates()[0], CandidateMetadata::Base));
+        assert_eq!(refreshed.candidates().len(), 3);
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -397,7 +397,7 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             //     function receives even after several optimizer passes
             //     rebuild the `OneOf` via `with_exprs_and_inputs`.
             let mut candidates = candidates;
-            candidates.sort_by(|a, b| a.1.to_string().cmp(&b.1.to_string()));
+            candidates.sort_by_key(|a| a.1.to_string());
 
             let branches: Vec<LogicalPlan> = std::iter::once(node)
                 .chain(candidates.iter().map(|(lp, _)| lp.clone()))
@@ -1118,7 +1118,7 @@ mod tests_rewrite_context {
             (mv_a_lp.clone(), TableReference::bare("catalog.schema.mv_a")),
             (mv_b_lp.clone(), TableReference::bare("catalog.schema.mv_b")),
         ];
-        candidates.sort_by(|a, b| a.1.to_string().cmp(&b.1.to_string()));
+        candidates.sort_by_key(|a| a.1.to_string());
 
         // Base first, then sorted MVs.
         let branches: Vec<LogicalPlan> = std::iter::once(base.clone())

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -69,52 +69,72 @@ use crate::materialized::cast_to_materialized;
 use super::normal_form::SpjNormalForm;
 use super::QueryRewriteOptions;
 
+/// Per-branch metadata inside a `OneOf` / `OneOfExec`. One variant per branch,
+/// aligned by index with the containing `branches` / `candidates` vector.
+///
+/// The invariant enforced at construction (see `ViewMatchingRewriter::f_down`):
+///
+/// * Index 0 is always [`CandidateMetadata::Base`] — the query's original LP,
+///   with no MV rewrite applied. `OneOf::schema()` reads `branches[0].schema()`
+///   and therefore always exposes the query's schema (not an MV's).
+/// * Indices 1..N are [`CandidateMetadata::Materialized`] entries, sorted
+///   deterministically by `table_ref`. Sorting on the MV's registered
+///   `TableReference` (rather than on the branch LP) keeps the order stable
+///   under downstream LP transformations that happen between LP rewrite and
+///   physical planning — identity projection elimination, always-true filter
+///   folding, etc. change the LP but never the MV's registered name, so the
+///   alignment between this metadata and the physical candidate the cost
+///   function receives survives every optimizer pass.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash)]
+pub enum CandidateMetadata {
+    /// The query's original branch (index 0 in every OneOf).
+    Base,
+    /// A materialized-view rewrite of the query.
+    Materialized {
+        /// Registered `TableReference` of the source MV. Stable across
+        /// LP transformations; safe to use as a sort key.
+        table_ref: String,
+        /// Total file count of the MV at LP-rewrite time, snapshotted from
+        /// [`Materialized::file_count()`](crate::materialized::Materialized::file_count).
+        ///
+        /// * `None` — provider doesn't expose file_count.
+        /// * `Some(0)` — MV is registered but not populated (e.g. newly-deployed
+        ///   MV whose ingest task hasn't run yet). Cost functions should
+        ///   reject it so an empty answer doesn't silently win.
+        /// * `Some(n)` — MV is populated. If the physical plan collapsed to
+        ///   an `EmptyExec`, that's predicate-pruning (should win via `-inf`
+        ///   cost), not an unpopulated MV.
+        file_count: Option<usize>,
+    },
+}
+
 /// Logical rewrite metadata propagated alongside equivalent candidate plans.
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd, Eq, Hash)]
 pub struct RewriteContext {
     root_table_refs: Vec<String>,
-    /// Per-branch source table reference. Index i corresponds to branch i in the
-    /// containing `OneOf` / `OneOfExec`, where index 0 is the base table branch
-    /// and indices 1..N are MV candidates. `None` marks the base branch (or a
-    /// candidate whose source isn't a materialized view); `Some(mv_ref)` gives
-    /// the MV's registered `TableReference` so cost functions can identify the
-    /// candidate even when the physical plan tree has collapsed to a bare
-    /// `EmptyExec` after predicate pruning.
-    candidate_table_refs: Vec<Option<String>>,
-    /// Per-branch total file count of the source MV, snapshotted at LP-rewrite
-    /// time from `Materialized::file_count()`. Aligned with `candidate_table_refs`.
-    ///
-    /// * `None` — base branch, or a candidate whose provider doesn't expose file_count
-    /// * `Some(0)` — MV is registered but has no files (e.g. newly-deployed MV whose
-    ///   ingest task hasn't run yet); cost functions should reject it so a query
-    ///   isn't silently answered with an empty result
-    /// * `Some(n)` — MV is populated with `n` files; if the physical plan collapsed
-    ///   to `EmptyExec`, that's predicate-pruning rather than an unpopulated MV, so
-    ///   the cost function should keep the `-inf` cost and let the MV win
-    candidate_file_counts: Vec<Option<usize>>,
+    /// Per-branch metadata aligned with the containing `OneOf` / `OneOfExec`
+    /// branch order. See [`CandidateMetadata`] for the alignment invariant.
+    /// Empty when no callsite has attached candidate metadata (backward
+    /// compatible with callers that pre-date the per-branch extensions).
+    candidates: Vec<CandidateMetadata>,
 }
 
 impl RewriteContext {
     /// Create a new rewrite context from the root table refs visible during rewrite.
-    /// Candidate lists start empty; use the `with_*` builders to attach per-branch data.
+    /// The candidate list starts empty; use [`Self::with_candidates`] to attach it.
     pub fn new(root_table_refs: Vec<String>) -> Self {
         Self {
             root_table_refs,
-            candidate_table_refs: Vec::new(),
-            candidate_file_counts: Vec::new(),
+            candidates: Vec::new(),
         }
     }
 
-    /// Attach the per-branch source table reference list. Consumes and returns `self`
-    /// so the builder chain stays readable at the OneOf construction site.
-    pub fn with_candidate_table_refs(mut self, candidate_table_refs: Vec<Option<String>>) -> Self {
-        self.candidate_table_refs = candidate_table_refs;
-        self
-    }
-
-    /// Attach per-branch file counts. See the field doc for population semantics.
-    pub fn with_candidate_file_counts(mut self, candidate_file_counts: Vec<Option<usize>>) -> Self {
-        self.candidate_file_counts = candidate_file_counts;
+    /// Attach the per-branch candidate metadata list. Consumes and returns
+    /// `self` so the builder chain stays readable at the OneOf construction
+    /// site. The caller must respect the alignment invariant documented on
+    /// [`CandidateMetadata`].
+    pub fn with_candidates(mut self, candidates: Vec<CandidateMetadata>) -> Self {
+        self.candidates = candidates;
         self
     }
 
@@ -123,17 +143,10 @@ impl RewriteContext {
         &self.root_table_refs
     }
 
-    /// Returns the per-branch source table refs, aligned with the candidate plan order.
-    /// Empty when no callsite has attached them (backward compatible with callers
-    /// that pre-date the per-branch metadata extensions).
-    pub fn candidate_table_refs(&self) -> &[Option<String>] {
-        &self.candidate_table_refs
-    }
-
-    /// Returns the per-branch source file counts, aligned with the candidate plan order.
-    /// Empty when no callsite has attached them.
-    pub fn candidate_file_counts(&self) -> &[Option<usize>] {
-        &self.candidate_file_counts
+    /// Returns the per-branch candidate metadata, aligned with the branch
+    /// order in the containing `OneOf` / `OneOfExec`.
+    pub fn candidates(&self) -> &[CandidateMetadata] {
+        &self.candidates
     }
 }
 
@@ -354,38 +367,41 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             log::trace!("no candidates");
             Ok(Transformed::no(node))
         } else {
-            // Build (LP, table_ref, file_count) triples: base is `None`, MV candidates
-            // carry their identity + populated-ness. We then sort in place using the
-            // SAME comparator `OneOf::inputs()` uses, so that:
-            //   * `self.branches` order matches `inputs()` order (sort becomes a no-op),
-            //   * `candidate_table_refs[i]` / `candidate_file_counts[i]` remain aligned
-            //     with the physical candidate the planner ultimately hands to the cost
-            //     function.
-            // Without this pre-sort, the metadata would stay in construction order
-            // while `inputs()` reorders the branches, silently misattributing MV
-            // identity/file_count to the wrong candidate — a populated pruned MV
-            // could lose, or an unpopulated MV could wrongly win.
-            let mut aligned: Vec<(LogicalPlan, Option<String>, Option<usize>)> =
-                std::iter::once((node, None, None))
-                    .chain(
-                        candidates
-                            .into_iter()
-                            .map(|(lp, r, fc)| (lp, Some(r.to_string()), fc)),
-                    )
-                    .collect();
-            aligned.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-            let branches: Vec<LogicalPlan> = aligned.iter().map(|(lp, _, _)| lp.clone()).collect();
-            let candidate_table_refs: Vec<Option<String>> =
-                aligned.iter().map(|(_, r, _)| r.clone()).collect();
-            let candidate_file_counts: Vec<Option<usize>> =
-                aligned.into_iter().map(|(_, _, fc)| fc).collect();
+            // Establish and preserve the alignment invariant documented on
+            // `CandidateMetadata`:
+            //   * `branches[0]` is always the base LP (so `OneOf::schema()`,
+            //     which reads `branches[0].schema()`, always exposes the
+            //     original query's schema — never an MV's schema, which may
+            //     differ in nullability or column qualification);
+            //   * `branches[1..]` are the MV candidates in a deterministic
+            //     order derived from each MV's `TableReference`, which is
+            //     stable under downstream LP transformations (identity
+            //     projection elimination, always-true filter folding, etc.
+            //     do not change an MV's registered name). This keeps the
+            //     metadata aligned with the physical candidate the cost
+            //     function receives even after several optimizer passes
+            //     rebuild the `OneOf` via `with_exprs_and_inputs`.
+            let mut candidates = candidates;
+            candidates.sort_by(|a, b| a.1.to_string().cmp(&b.1.to_string()));
+
+            let branches: Vec<LogicalPlan> = std::iter::once(node)
+                .chain(candidates.iter().map(|(lp, _, _)| lp.clone()))
+                .collect();
+            let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
+                .chain(candidates.into_iter().map(|(_, table_ref, file_count)| {
+                    CandidateMetadata::Materialized {
+                        table_ref: table_ref.to_string(),
+                        file_count,
+                    }
+                }))
+                .collect();
+
             Ok(Transformed::new(
                 LogicalPlan::Extension(Extension {
                     node: Arc::new(OneOf::with_rewrite_context(
                         branches,
                         RewriteContext::new(vec![table_reference.to_string()])
-                            .with_candidate_table_refs(candidate_table_refs)
-                            .with_candidate_file_counts(candidate_file_counts),
+                            .with_candidates(metadata),
                     )),
                 }),
                 true,
@@ -518,10 +534,20 @@ impl UserDefinedLogicalNodeCore for OneOf {
     }
 
     fn inputs(&self) -> Vec<&LogicalPlan> {
-        self.branches
-            .iter()
-            .sorted_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-            .collect_vec()
+        // Return branches in stored order so `RewriteContext::candidates` stays
+        // aligned across `with_exprs_and_inputs` rebuilds. Determinism is
+        // supplied by `ViewMatchingRewriter::f_down`, which puts the base at
+        // index 0 and sorts MV candidates by `TableReference` (an identifier
+        // that survives downstream LP transformations).
+        //
+        // The previous implementation re-sorted on every call using
+        // `LogicalPlan::partial_cmp`, which flipped the order whenever an
+        // optimizer pass changed a branch's LP shape (identity projection
+        // elimination, always-true filter folding, etc.). That silently
+        // misattributed per-branch metadata after any tree rebuild — and
+        // moved the base branch off `branches[0]`, so `OneOf::schema()`
+        // could expose an MV's schema instead of the query's.
+        self.branches.iter().collect_vec()
     }
 
     fn schema(&self) -> &datafusion_common::DFSchemaRef {
@@ -896,90 +922,170 @@ mod tests_rewrite_context {
     }
 
     #[test]
-    fn rewrite_context_defaults_candidate_lists_to_empty() {
-        // `RewriteContext::new` must leave the new per-branch lists empty so any
-        // caller that pre-dates the per-branch metadata extensions keeps its
+    fn rewrite_context_defaults_candidates_to_empty() {
+        // `RewriteContext::new` must leave the candidate metadata empty so any
+        // caller that pre-dates the per-branch metadata extension keeps its
         // original behaviour (downstream discriminators fall back to their
         // existing signals when the slice is empty).
         let ctx = RewriteContext::new(vec!["catalog.schema.root".to_string()]);
-        assert!(ctx.candidate_table_refs().is_empty());
-        assert!(ctx.candidate_file_counts().is_empty());
+        assert!(ctx.candidates().is_empty());
     }
 
     #[test]
-    fn rewrite_context_builders_attach_candidate_metadata() {
-        let ctx = RewriteContext::new(vec!["catalog.schema.root".to_string()])
-            .with_candidate_table_refs(vec![
-                None,
-                Some("catalog.schema.mv_a".to_string()),
-                Some("catalog.schema.mv_b".to_string()),
-            ])
-            .with_candidate_file_counts(vec![None, Some(0), Some(100)]);
+    fn rewrite_context_builder_attaches_candidate_metadata() {
+        let ctx =
+            RewriteContext::new(vec!["catalog.schema.root".to_string()]).with_candidates(vec![
+                CandidateMetadata::Base,
+                CandidateMetadata::Materialized {
+                    table_ref: "catalog.schema.mv_a".to_string(),
+                    file_count: Some(0),
+                },
+                CandidateMetadata::Materialized {
+                    table_ref: "catalog.schema.mv_b".to_string(),
+                    file_count: Some(100),
+                },
+            ]);
 
-        assert_eq!(
-            ctx.candidate_table_refs(),
-            &[
-                None,
-                Some("catalog.schema.mv_a".to_string()),
-                Some("catalog.schema.mv_b".to_string()),
-            ]
-        );
-        assert_eq!(ctx.candidate_file_counts(), &[None, Some(0), Some(100)]);
+        let cands = ctx.candidates();
+        assert_eq!(cands.len(), 3);
+        assert!(matches!(cands[0], CandidateMetadata::Base));
+        assert!(matches!(
+            cands[1],
+            CandidateMetadata::Materialized {
+                ref table_ref,
+                file_count: Some(0),
+            } if table_ref == "catalog.schema.mv_a"
+        ));
+        assert!(matches!(
+            cands[2],
+            CandidateMetadata::Materialized {
+                ref table_ref,
+                file_count: Some(100),
+            } if table_ref == "catalog.schema.mv_b"
+        ));
     }
 
     #[test]
-    fn one_of_branches_and_candidate_metadata_share_ordering() {
-        // Invariant: whatever ordering `OneOf::inputs()` exposes to the DataFusion
-        // planner (and therefore to `plan_extension`'s `physical_inputs`), the
-        // `candidate_table_refs` / `candidate_file_counts` slices must line up.
-        // `ViewMatchingRewriter::f_down` pre-sorts branches + metadata together so
-        // `inputs()`'s sort is a no-op; this test guards that invariant from
-        // regressing (e.g. by someone appending metadata after the sort or by
-        // `inputs()` gaining a different comparator).
-        use itertools::Itertools;
-
+    fn one_of_inputs_returns_stored_order_without_resort() {
+        // Regression test: `OneOf::inputs()` used to re-sort by
+        // `LogicalPlan::partial_cmp`, which flipped branch order whenever a
+        // downstream optimizer pass mutated a branch (identity Projection
+        // elimination, always-true Filter folding, etc.) and silently
+        // misattributed per-branch metadata. `inputs()` must return the
+        // stored order verbatim so alignment with
+        // `RewriteContext::candidates()` survives every rebuild.
         let base = LogicalPlanBuilder::empty(false)
             .build()
             .expect("empty base plan");
         let candidate_a = LogicalPlanBuilder::empty(true)
             .build()
             .expect("candidate a plan");
-        // Assemble in a deliberately non-sorted order so we exercise the invariant.
-        let mut aligned: Vec<(LogicalPlan, Option<String>, Option<usize>)> = vec![
-            (
-                candidate_a.clone(),
-                Some("catalog.schema.mv_a".to_string()),
-                Some(42),
-            ),
-            (base.clone(), None, None),
-        ];
-        aligned.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-        let branches: Vec<LogicalPlan> = aligned.iter().map(|(lp, _, _)| lp.clone()).collect();
-        let refs: Vec<Option<String>> = aligned.iter().map(|(_, r, _)| r.clone()).collect();
-        let counts: Vec<Option<usize>> = aligned.iter().map(|(_, _, fc)| *fc).collect();
-
+        // Store in a deliberately non-sorted order to prove `inputs()` is a
+        // no-op — if it re-sorted, `candidate_a` would come before `base`
+        // (nullable schema sorts differently) and this assertion would fail.
+        let branches = vec![base.clone(), candidate_a.clone()];
         let one_of = OneOf::with_rewrite_context(
             branches.clone(),
-            RewriteContext::new(vec!["catalog.schema.root".to_string()])
-                .with_candidate_table_refs(refs.clone())
-                .with_candidate_file_counts(counts.clone()),
+            RewriteContext::new(vec!["catalog.schema.root".to_string()]).with_candidates(vec![
+                CandidateMetadata::Base,
+                CandidateMetadata::Materialized {
+                    table_ref: "catalog.schema.mv_a".to_string(),
+                    file_count: Some(42),
+                },
+            ]),
         );
 
-        // Simulate the planner call: `inputs()` returns the branches in sort order.
-        let inputs_order: Vec<&LogicalPlan> = UserDefinedLogicalNodeCore::inputs(&one_of)
-            .into_iter()
-            .collect_vec();
+        let exposed = UserDefinedLogicalNodeCore::inputs(&one_of);
+        assert_eq!(exposed.len(), 2);
+        assert_eq!(*exposed[0], base, "index 0 must remain the base branch");
+        assert_eq!(*exposed[1], candidate_a);
+    }
 
-        // Because the pre-sort in the rewriter matches the sort inside inputs(), the
-        // exposed branch order must equal the stored branch order — index i in
-        // `inputs()` corresponds to index i in the metadata vectors.
-        for (i, exposed) in inputs_order.iter().enumerate() {
-            assert_eq!(
-                *exposed, &branches[i],
-                "OneOf::inputs()[{i}] must match self.branches[{i}] for metadata to stay aligned"
-            );
-        }
-        assert_eq!(one_of.rewrite_context().candidate_table_refs(), refs);
-        assert_eq!(one_of.rewrite_context().candidate_file_counts(), counts);
+    #[test]
+    fn one_of_schema_always_reports_base_branch_schema() {
+        // `OneOf::schema()` reads `branches[0].schema()`. The X-3269 fix must
+        // never move the base branch off index 0 — if an MV's LP sorted
+        // first, the parent `OneOf` would expose an MV's schema (possibly
+        // with different nullability / column qualification) instead of the
+        // query's schema, silently changing DataFusion's downstream planning.
+        //
+        // We construct the OneOf directly here (bypassing `f_down`) to check
+        // that whichever order the caller stores, `schema()` picks up
+        // `branches[0]`. `ViewMatchingRewriter::f_down` guarantees the caller
+        // always puts base at index 0, so together this locks in the
+        // "index 0 is base, and its schema is the query schema" invariant.
+        let base_nonnull = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let candidate_nullable = LogicalPlanBuilder::empty(true)
+            .build()
+            .expect("nullable candidate plan");
+
+        let one_of_base_first = OneOf::with_rewrite_context(
+            vec![base_nonnull.clone(), candidate_nullable.clone()],
+            RewriteContext::default(),
+        );
+        assert_eq!(
+            UserDefinedLogicalNodeCore::schema(&one_of_base_first),
+            base_nonnull.schema()
+        );
+    }
+
+    #[test]
+    fn one_of_alignment_survives_with_exprs_and_inputs_rebuild() {
+        // Once branches are stored in a stable order, DataFusion's
+        // `TreeNodeRewriter` walks children by index and rebuilds the parent
+        // via `with_exprs_and_inputs`, keeping the positional contract.
+        // Even after a transformation swaps one branch for a differently-
+        // shaped LP, the rebuilt OneOf must keep every candidate's metadata
+        // aligned with the (possibly transformed) branch at the same index.
+        let base = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let candidate = LogicalPlanBuilder::empty(true)
+            .build()
+            .expect("candidate plan");
+
+        let mv_meta = CandidateMetadata::Materialized {
+            table_ref: "catalog.schema.mv_a".to_string(),
+            file_count: Some(2_090_783_849),
+        };
+        let one_of = OneOf::with_rewrite_context(
+            vec![base.clone(), candidate.clone()],
+            RewriteContext::new(vec!["catalog.schema.root".to_string()])
+                .with_candidates(vec![CandidateMetadata::Base, mv_meta.clone()]),
+        );
+
+        // Simulate an optimizer pass rewriting the MV branch (e.g. injecting
+        // a Filter). `with_exprs_and_inputs` returns a new OneOf with the
+        // rewritten branch at the SAME index — never re-sorted.
+        let rewritten_candidate = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("rewritten candidate plan");
+        let rebuilt = UserDefinedLogicalNodeCore::with_exprs_and_inputs(
+            &one_of,
+            vec![],
+            vec![base.clone(), rewritten_candidate.clone()],
+        )
+        .expect("rebuild OneOf");
+
+        // Base still at index 0.
+        assert_eq!(
+            UserDefinedLogicalNodeCore::schema(&rebuilt),
+            base.schema(),
+            "OneOf::schema() must still resolve to the base branch schema"
+        );
+        // Metadata still aligned: index 0 = Base, index 1 = the same MV
+        // identity/file_count even though its LP changed.
+        assert_eq!(rebuilt.rewrite_context().candidates().len(), 2);
+        assert!(matches!(
+            rebuilt.rewrite_context().candidates()[0],
+            CandidateMetadata::Base
+        ));
+        assert_eq!(rebuilt.rewrite_context().candidates()[1], mv_meta);
+        // Exposed inputs match stored order, MV at index 1 is the transformed LP.
+        let exposed = UserDefinedLogicalNodeCore::inputs(&rebuilt);
+        assert_eq!(*exposed[0], base);
+        assert_eq!(*exposed[1], rewritten_candidate);
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -64,7 +64,7 @@ use datafusion_physical_expr::OrderingRequirements;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 
-use crate::materialized::cast_to_materialized;
+use crate::materialized::{cast_to_materialized, RewriteReadiness};
 
 use super::normal_form::SpjNormalForm;
 use super::QueryRewriteOptions;
@@ -75,8 +75,12 @@ use super::QueryRewriteOptions;
 /// Lifecycle judgement (populated / unpopulated / stale / ...) is made upstream
 /// by [`ViewMatcher`] via
 /// [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness):
-/// `NotReady` MVs never reach the candidate set at all, so any
-/// `Materialized` variant that shows up here is safe to route queries to.
+/// only `NotReady` MVs are dropped from the candidate set. `Ready` and
+/// `Unknown` both reach the cost function, and the raw readiness reported by
+/// the provider is preserved in [`CandidateMetadata::Materialized::readiness`]
+/// so cost policy for the two cases can diverge (typically:
+/// trust `Ready` as safe to route, and fall back to a conservative estimate
+/// for `Unknown`).
 ///
 /// The invariant enforced at construction inside [`ViewMatcher`]:
 ///
@@ -97,11 +101,21 @@ pub enum CandidateMetadata {
     Base,
     /// A materialized-view rewrite of the query. Only MVs that reported
     /// `Ready` or `Unknown` readiness reach this state; `NotReady` MVs
-    /// are filtered upstream by [`ViewMatcher`].
+    /// are filtered upstream by [`ViewMatcher`]. Cost functions consult
+    /// [`Self::Materialized::readiness`] to distinguish the two cases —
+    /// `Unknown` (the trait default) must not be silently treated as
+    /// `Ready`, since that would regress providers that haven't declared
+    /// a lifecycle.
     Materialized {
         /// Registered `TableReference` of the source MV. Stable across
         /// LP transformations; safe to use as a sort key.
         table_ref: String,
+        /// Readiness reported by the provider at LP rewrite time.
+        /// Preserved verbatim so downstream cost functions can implement
+        /// their own policy for the `Unknown` case (e.g. fall back to the
+        /// base scan cost rather than trust an EmptyExec as
+        /// predicate-pruned).
+        readiness: RewriteReadiness,
     },
 }
 
@@ -340,7 +354,16 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
         // cost function. Lifecycle correctness lives in the provider (see
         // `Materialized::rewrite_readiness`); the cost function then only
         // sees candidates it can safely route queries to.
-        let candidates: Vec<(LogicalPlan, TableReference)> = self
+        //
+        // `Ready` and `Unknown` both survive here, but the readiness value is
+        // preserved and carried through into `CandidateMetadata::Materialized`
+        // so cost functions can distinguish the two: `Ready` == the provider
+        // guarantees the MV is safe to answer the query; `Unknown` == the
+        // provider doesn't know and the cost function should apply its own
+        // conservative policy (e.g. avoid trusting an EmptyExec candidate as
+        // predicate-pruned). Erasing the readiness at this layer would silently
+        // promote every default (`Unknown`) provider to `Ready`.
+        let candidates: Vec<(LogicalPlan, TableReference, RewriteReadiness)> = self
             .parent
             .mv_plans
             .iter()
@@ -361,16 +384,16 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                 // function decides" default) so the rewrite path keeps functioning.
                 let readiness = match cast_to_materialized(table.as_ref()) {
                     Ok(Some(mv)) => mv.rewrite_readiness(),
-                    Ok(None) => crate::materialized::RewriteReadiness::Unknown,
+                    Ok(None) => RewriteReadiness::Unknown,
                     Err(e) => {
                         log::warn!(
                             "cast_to_materialized failed for {table_ref}: {e}; \
                              treating as Unknown readiness"
                         );
-                        crate::materialized::RewriteReadiness::Unknown
+                        RewriteReadiness::Unknown
                     }
                 };
-                if matches!(readiness, crate::materialized::RewriteReadiness::NotReady) {
+                if matches!(readiness, RewriteReadiness::NotReady) {
                     log::trace!("skipping NotReady MV: {table_ref}");
                     return None;
                 }
@@ -380,14 +403,14 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                     provider_as_source(Arc::clone(table)),
                 )
                 .transpose()
-                .map(|res| res.map(|lp| (lp, table_ref.clone())))
+                .map(|res| res.map(|lp| (lp, table_ref.clone(), readiness)))
             })
             .flat_map(|res| match res {
                 Err(e) => {
                     log::trace!("error rewriting: {e}");
                     None
                 }
-                Ok(pair) => Some(pair),
+                Ok(triple) => Some(triple),
             })
             .collect();
 
@@ -413,12 +436,13 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             candidates.sort_by_key(|a| a.1.to_string());
 
             let branches: Vec<LogicalPlan> = std::iter::once(node)
-                .chain(candidates.iter().map(|(lp, _)| lp.clone()))
+                .chain(candidates.iter().map(|(lp, _, _)| lp.clone()))
                 .collect();
             let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
-                .chain(candidates.into_iter().map(|(_, table_ref)| {
+                .chain(candidates.into_iter().map(|(_, table_ref, readiness)| {
                     CandidateMetadata::Materialized {
                         table_ref: table_ref.to_string(),
+                        readiness,
                     }
                 }))
                 .collect();
@@ -965,9 +989,11 @@ mod tests_rewrite_context {
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
                     table_ref: "catalog.schema.mv_a".to_string(),
+                    readiness: RewriteReadiness::Ready,
                 },
                 CandidateMetadata::Materialized {
                     table_ref: "catalog.schema.mv_b".to_string(),
+                    readiness: RewriteReadiness::Unknown,
                 },
             ]);
 
@@ -978,12 +1004,14 @@ mod tests_rewrite_context {
             cands[1],
             CandidateMetadata::Materialized {
                 ref table_ref,
+                readiness: RewriteReadiness::Ready,
             } if table_ref == "catalog.schema.mv_a"
         ));
         assert!(matches!(
             cands[2],
             CandidateMetadata::Materialized {
                 ref table_ref,
+                readiness: RewriteReadiness::Unknown,
             } if table_ref == "catalog.schema.mv_b"
         ));
     }
@@ -1013,6 +1041,7 @@ mod tests_rewrite_context {
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
                     table_ref: "catalog.schema.mv_a".to_string(),
+                    readiness: RewriteReadiness::Ready,
                 },
             ]),
         );
@@ -1070,6 +1099,7 @@ mod tests_rewrite_context {
 
         let mv_meta = CandidateMetadata::Materialized {
             table_ref: "catalog.schema.mv_a".to_string(),
+            readiness: RewriteReadiness::Ready,
         };
         let one_of = OneOf::with_rewrite_context(
             vec![base.clone(), candidate.clone()],
@@ -1126,25 +1156,36 @@ mod tests_rewrite_context {
 
         // Deliberately non-sorted insertion order (as would happen with
         // `mv_plans` HashMap iteration).
-        let mut candidates: Vec<(LogicalPlan, TableReference)> = vec![
-            (mv_c_lp.clone(), TableReference::bare("catalog.schema.mv_c")),
-            (mv_a_lp.clone(), TableReference::bare("catalog.schema.mv_a")),
-            (mv_b_lp.clone(), TableReference::bare("catalog.schema.mv_b")),
+        let mut candidates: Vec<(LogicalPlan, TableReference, RewriteReadiness)> = vec![
+            (
+                mv_c_lp.clone(),
+                TableReference::bare("catalog.schema.mv_c"),
+                RewriteReadiness::Ready,
+            ),
+            (
+                mv_a_lp.clone(),
+                TableReference::bare("catalog.schema.mv_a"),
+                RewriteReadiness::Ready,
+            ),
+            (
+                mv_b_lp.clone(),
+                TableReference::bare("catalog.schema.mv_b"),
+                RewriteReadiness::Ready,
+            ),
         ];
         candidates.sort_by_key(|a| a.1.to_string());
 
         // Base first, then sorted MVs.
         let branches: Vec<LogicalPlan> = std::iter::once(base.clone())
-            .chain(candidates.iter().map(|(lp, _)| lp.clone()))
+            .chain(candidates.iter().map(|(lp, _, _)| lp.clone()))
             .collect();
         let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
-            .chain(
-                candidates
-                    .into_iter()
-                    .map(|(_, r)| CandidateMetadata::Materialized {
-                        table_ref: r.to_string(),
-                    }),
-            )
+            .chain(candidates.into_iter().map(|(_, r, readiness)| {
+                CandidateMetadata::Materialized {
+                    table_ref: r.to_string(),
+                    readiness,
+                }
+            }))
             .collect();
 
         assert_eq!(branches[0], base, "index 0 must be base");
@@ -1152,19 +1193,22 @@ mod tests_rewrite_context {
         assert_eq!(
             metadata[1],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_a".to_string()
+                table_ref: "catalog.schema.mv_a".to_string(),
+                readiness: RewriteReadiness::Ready,
             }
         );
         assert_eq!(
             metadata[2],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_b".to_string()
+                table_ref: "catalog.schema.mv_b".to_string(),
+                readiness: RewriteReadiness::Ready,
             }
         );
         assert_eq!(
             metadata[3],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_c".to_string()
+                table_ref: "catalog.schema.mv_c".to_string(),
+                readiness: RewriteReadiness::Ready,
             }
         );
     }
@@ -1188,16 +1232,22 @@ mod tests_view_matcher_readiness_filter {
     use datafusion_expr::builder::LogicalTableSource;
     use datafusion_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicU8, Ordering};
     use std::sync::Arc;
 
     /// Mock Materialized provider with a caller-selectable readiness value.
     /// The `query` is a trivial `TableScan(source_table)` so the rewriter's
     /// `SpjNormalForm` handling can trivially match a base LP against it.
+    ///
+    /// `readiness` is stored in an `AtomicU8` so tests that need to simulate
+    /// lifecycle transitions (e.g. a cold lazy index reporting `Unknown`
+    /// during the first rewrite pass and `Ready` after the scan initialises
+    /// it) can flip the value without rebuilding the whole `ViewMatcher`.
     #[derive(Debug)]
     struct MockMv {
         source_table: String,
         query: LogicalPlan,
-        readiness: RewriteReadiness,
+        readiness: AtomicU8,
     }
 
     impl MockMv {
@@ -1211,8 +1261,29 @@ mod tests_view_matcher_readiness_filter {
             Arc::new(Self {
                 source_table: source_table.to_string(),
                 query,
-                readiness,
+                readiness: AtomicU8::new(encode_readiness(readiness)),
             })
+        }
+
+        fn set_readiness(&self, readiness: RewriteReadiness) {
+            self.readiness
+                .store(encode_readiness(readiness), Ordering::SeqCst);
+        }
+    }
+
+    fn encode_readiness(r: RewriteReadiness) -> u8 {
+        match r {
+            RewriteReadiness::Ready => 0,
+            RewriteReadiness::NotReady => 1,
+            RewriteReadiness::Unknown => 2,
+        }
+    }
+
+    fn decode_readiness(v: u8) -> RewriteReadiness {
+        match v {
+            0 => RewriteReadiness::Ready,
+            1 => RewriteReadiness::NotReady,
+            _ => RewriteReadiness::Unknown,
         }
     }
 
@@ -1254,7 +1325,7 @@ mod tests_view_matcher_readiness_filter {
             self.query.clone()
         }
         fn rewrite_readiness(&self) -> RewriteReadiness {
-            self.readiness
+            decode_readiness(self.readiness.load(Ordering::SeqCst))
         }
     }
 
@@ -1311,7 +1382,7 @@ mod tests_view_matcher_readiness_filter {
             .candidates()
             .iter()
             .filter_map(|c| match c {
-                CandidateMetadata::Materialized { table_ref } => Some(table_ref.clone()),
+                CandidateMetadata::Materialized { table_ref, .. } => Some(table_ref.clone()),
                 CandidateMetadata::Base => None,
             })
             .collect()
@@ -1375,5 +1446,145 @@ mod tests_view_matcher_readiness_filter {
             !matches!(&rewritten, LogicalPlan::Extension(ext) if ext.node.as_any().is::<OneOf>()),
             "no candidate MV survived, so the rewriter must return the base LP untouched. got={rewritten:?}"
         );
+    }
+
+    /// Return the full metadata slice from the OneOf wrapping `plan`.
+    fn candidate_metadata(plan: &LogicalPlan) -> Vec<CandidateMetadata> {
+        let LogicalPlan::Extension(ext) = plan else {
+            panic!("expected OneOf extension, got {plan:?}");
+        };
+        let one_of = ext
+            .node
+            .as_any()
+            .downcast_ref::<OneOf>()
+            .expect("OneOf node");
+        one_of.rewrite_context().candidates().to_vec()
+    }
+
+    #[test]
+    fn f_down_encodes_ready_and_unknown_readiness_verbatim() {
+        // Regression test for the "readiness must reach the cost function"
+        // contract. Prior to this fix `f_down` collapsed `Ready` and `Unknown`
+        // into a single `CandidateMetadata::Materialized { table_ref }` shape,
+        // which meant a cost function that trusted `Materialized` candidates
+        // as predicate-pruned would silently promote every default-`Unknown`
+        // provider to `Ready`. `CandidateMetadata::Materialized` now carries
+        // the raw readiness so downstream policy can branch on it.
+        let matcher = build_matcher_with_three_readiness_states("target_t");
+        let rewritten = rewrite_scan_lp(&matcher, "target_t");
+
+        let metadata = candidate_metadata(&rewritten);
+        // Base + Ready + Unknown = 3 entries; NotReady was dropped upstream.
+        assert_eq!(metadata.len(), 3, "expected Base + Ready + Unknown");
+        assert!(matches!(metadata[0], CandidateMetadata::Base));
+
+        let ready = metadata
+            .iter()
+            .find_map(|c| match c {
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } if table_ref == "mv_ready" => Some(*readiness),
+                _ => None,
+            })
+            .expect("Ready MV should be a candidate");
+        assert_eq!(ready, RewriteReadiness::Ready);
+
+        let unknown = metadata
+            .iter()
+            .find_map(|c| match c {
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } if table_ref == "mv_unknown" => Some(*readiness),
+                _ => None,
+            })
+            .expect("Unknown MV should be a candidate");
+        assert_eq!(unknown, RewriteReadiness::Unknown);
+    }
+
+    #[test]
+    fn f_down_metadata_length_matches_branch_count() {
+        // Alignment invariant: `RewriteContext::candidates()` must have one
+        // entry per branch in the OneOf so the cost function can index into
+        // the two slices in lockstep. This is easy to break when a new field
+        // is added to `CandidateMetadata::Materialized`.
+        let matcher = build_matcher_with_three_readiness_states("target_t");
+        let rewritten = rewrite_scan_lp(&matcher, "target_t");
+
+        let LogicalPlan::Extension(ext) = &rewritten else {
+            panic!("expected Extension");
+        };
+        let one_of = ext
+            .node
+            .as_any()
+            .downcast_ref::<OneOf>()
+            .expect("OneOf node");
+        let branches = UserDefinedLogicalNodeCore::inputs(one_of);
+        let metadata = one_of.rewrite_context().candidates();
+        assert_eq!(
+            branches.len(),
+            metadata.len(),
+            "branches ({}) must have the same length as metadata ({}): {:?}",
+            branches.len(),
+            metadata.len(),
+            metadata
+        );
+    }
+
+    #[test]
+    fn f_down_admits_unknown_provider_across_lifecycle_transition() {
+        // Scenario: a provider that uses a lazy-loaded index reports
+        // `Unknown` on its first rewrite pass (index cold, not yet queried)
+        // and `Ready` once the scan has initialised it. Reporting `NotReady`
+        // in the cold phase would filter the MV out here, the scan would
+        // never plan, and the index would stay cold forever — a rewrite-time
+        // deadlock. The recommended provider policy is therefore to report
+        // `Unknown` in the cold phase; this test locks in that (a) `f_down`
+        // admits `Unknown`, and (b) once the provider transitions to `Ready`
+        // the next rewrite reports the new readiness verbatim, so the cost
+        // function can pick the more aggressive policy for it.
+        crate::materialized::register_materialized::<MockMv>();
+        let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
+        let form = SpjNormalForm::new(&mv.query).expect("valid SPJ");
+        let mut plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)> =
+            HashMap::new();
+        plans.insert(
+            TableReference::bare("mv_cold_lazy"),
+            (Arc::clone(&mv) as Arc<dyn TableProvider>, form),
+        );
+        let matcher = ViewMatcher::from_mv_plans_for_test(plans);
+
+        // First pass: cold => Unknown, must survive the filter with
+        // `readiness = Unknown` propagated into the metadata.
+        let cold = rewrite_scan_lp(&matcher, "target_t");
+        let cold_meta = candidate_metadata(&cold);
+        let cold_readiness = cold_meta
+            .iter()
+            .find_map(|c| match c {
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } if table_ref == "mv_cold_lazy" => Some(*readiness),
+                _ => None,
+            })
+            .expect("cold-lazy MV must be admitted as Unknown, not filtered");
+        assert_eq!(cold_readiness, RewriteReadiness::Unknown);
+
+        // Second pass after the (mock) scan has warmed the index.
+        mv.set_readiness(RewriteReadiness::Ready);
+        let warm = rewrite_scan_lp(&matcher, "target_t");
+        let warm_meta = candidate_metadata(&warm);
+        let warm_readiness = warm_meta
+            .iter()
+            .find_map(|c| match c {
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } if table_ref == "mv_cold_lazy" => Some(*readiness),
+                _ => None,
+            })
+            .expect("warm MV must still be a candidate");
+        assert_eq!(warm_readiness, RewriteReadiness::Ready);
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -1212,6 +1212,141 @@ mod tests_rewrite_context {
             }
         );
     }
+
+    #[test]
+    fn multi_mv_sort_key_is_table_ref_not_readiness() {
+        // Regression guard: sorting the candidate list by
+        // `TableReference::to_string()` must be stable regardless of the
+        // readiness field. Otherwise the alignment invariant between the
+        // branch order and the metadata order would depend on a field the
+        // cost function is *also* reading — a subtle coupling. Build a
+        // mixed-readiness set and check that the lexicographic table_ref
+        // order is preserved: mv_a (Unknown), mv_b (Ready), mv_c (Unknown).
+        let base = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let mv_a_lp = LogicalPlanBuilder::empty(true).build().expect("mv_a plan");
+        let mv_b_lp = LogicalPlanBuilder::empty(true).build().expect("mv_b plan");
+        let mv_c_lp = LogicalPlanBuilder::empty(true).build().expect("mv_c plan");
+        let mut candidates: Vec<(LogicalPlan, TableReference, RewriteReadiness)> = vec![
+            (
+                mv_c_lp,
+                TableReference::bare("catalog.schema.mv_c"),
+                RewriteReadiness::Unknown,
+            ),
+            (
+                mv_a_lp,
+                TableReference::bare("catalog.schema.mv_a"),
+                RewriteReadiness::Unknown,
+            ),
+            (
+                mv_b_lp,
+                TableReference::bare("catalog.schema.mv_b"),
+                RewriteReadiness::Ready,
+            ),
+        ];
+        candidates.sort_by_key(|a| a.1.to_string());
+
+        let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
+            .chain(candidates.into_iter().map(|(_, r, readiness)| {
+                CandidateMetadata::Materialized {
+                    table_ref: r.to_string(),
+                    readiness,
+                }
+            }))
+            .collect();
+
+        // Lex order by table_ref, readiness untouched.
+        assert_eq!(
+            metadata[1],
+            CandidateMetadata::Materialized {
+                table_ref: "catalog.schema.mv_a".to_string(),
+                readiness: RewriteReadiness::Unknown,
+            }
+        );
+        assert_eq!(
+            metadata[2],
+            CandidateMetadata::Materialized {
+                table_ref: "catalog.schema.mv_b".to_string(),
+                readiness: RewriteReadiness::Ready,
+            }
+        );
+        assert_eq!(
+            metadata[3],
+            CandidateMetadata::Materialized {
+                table_ref: "catalog.schema.mv_c".to_string(),
+                readiness: RewriteReadiness::Unknown,
+            }
+        );
+        // Silence dead-code warning on the surrounding `base` binding.
+        let _ = base;
+    }
+
+    #[test]
+    fn candidate_metadata_partial_eq_discriminates_readiness() {
+        // `PartialEq` on `CandidateMetadata::Materialized` must consider
+        // the readiness field. Otherwise a cost function relying on
+        // `matches!(..., readiness: Ready)` or a `HashSet<CandidateMetadata>`
+        // dedup would silently conflate a `Ready` variant with an `Unknown`
+        // variant on the same table_ref — reintroducing the exact regression
+        // this PR fixes.
+        let ready = CandidateMetadata::Materialized {
+            table_ref: "catalog.schema.mv_a".to_string(),
+            readiness: RewriteReadiness::Ready,
+        };
+        let unknown = CandidateMetadata::Materialized {
+            table_ref: "catalog.schema.mv_a".to_string(),
+            readiness: RewriteReadiness::Unknown,
+        };
+        assert_ne!(ready, unknown);
+
+        // Same readiness + same table_ref must still compare equal so
+        // dedup / cache-key uses still work.
+        let ready_again = CandidateMetadata::Materialized {
+            table_ref: "catalog.schema.mv_a".to_string(),
+            readiness: RewriteReadiness::Ready,
+        };
+        assert_eq!(ready, ready_again);
+    }
+
+    #[test]
+    fn one_of_alignment_survives_rebuild_with_unknown_readiness() {
+        // Regression for the `Unknown` half of the readiness contract.
+        // `one_of_alignment_survives_with_exprs_and_inputs_rebuild` only
+        // covers `Ready`; this variant proves that an `Unknown` readiness
+        // label is preserved verbatim across a `with_exprs_and_inputs`
+        // rebuild too, i.e. no downstream code path erases it once a
+        // subsequent optimizer pass rebuilds the parent OneOf.
+        let base = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let candidate = LogicalPlanBuilder::empty(true)
+            .build()
+            .expect("candidate plan");
+
+        let mv_meta = CandidateMetadata::Materialized {
+            table_ref: "catalog.schema.mv_cold_lazy".to_string(),
+            readiness: RewriteReadiness::Unknown,
+        };
+        let one_of = OneOf::with_rewrite_context(
+            vec![base.clone(), candidate.clone()],
+            RewriteContext::new(vec!["catalog.schema.root".to_string()])
+                .with_candidates(vec![CandidateMetadata::Base, mv_meta.clone()]),
+        );
+
+        let rewritten_candidate = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("rewritten candidate plan");
+        let rebuilt = UserDefinedLogicalNodeCore::with_exprs_and_inputs(
+            &one_of,
+            vec![],
+            vec![base.clone(), rewritten_candidate],
+        )
+        .expect("rebuild OneOf");
+
+        // The Unknown-readiness metadata survived verbatim.
+        assert_eq!(rebuilt.rewrite_context().candidates()[1], mv_meta);
+    }
 }
 
 /// End-to-end coverage for `ViewMatchingRewriter::f_down`'s `NotReady`

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -84,12 +84,12 @@ pub struct RewriteContext {
     /// Per-branch total file count of the source MV, snapshotted at LP-rewrite
     /// time from `Materialized::file_count()`. Aligned with `candidate_table_refs`.
     ///
-    /// * `None`     — base branch, or a candidate whose provider doesn't expose file_count
-    /// * `Some(0)`  — MV is registered but has no files (X-2174 case: newly-deployed MV
-    ///                whose ingest task hasn't run yet — cost function should reject it)
-    /// * `Some(N)`  — MV is populated with N files (X-3269 case: if the physical plan
-    ///                collapsed to EmptyExec, that's predicate-pruning, not un-population;
-    ///                cost function should keep the -inf cost so the MV wins)
+    /// * `None` — base branch, or a candidate whose provider doesn't expose file_count
+    /// * `Some(0)` — MV is registered but has no files (X-2174 case: newly-deployed MV
+    ///   whose ingest task hasn't run yet — cost function should reject it)
+    /// * `Some(n)` — MV is populated with `n` files (X-3269 case: if the physical plan
+    ///   collapsed to EmptyExec, that's predicate-pruning, not an unpopulated MV, so the
+    ///   cost function should keep the `-inf` cost and let the MV win)
     candidate_file_counts: Vec<Option<usize>>,
 }
 
@@ -112,10 +112,7 @@ impl RewriteContext {
     }
 
     /// Attach per-branch file counts. See the field doc for population semantics.
-    pub fn with_candidate_file_counts(
-        mut self,
-        candidate_file_counts: Vec<Option<usize>>,
-    ) -> Self {
+    pub fn with_candidate_file_counts(mut self, candidate_file_counts: Vec<Option<usize>>) -> Self {
         self.candidate_file_counts = candidate_file_counts;
         self
     }
@@ -354,19 +351,31 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             log::trace!("no candidates");
             Ok(Transformed::no(node))
         } else {
-            // Base branch is the query's original LP (no MV source) → None; MV
-            // branches carry their `TableReference` + `file_count` so cost functions
-            // can distinguish predicate-pruned populated MVs (X-3269, keep -inf) from
-            // genuinely-unpopulated MVs (X-2174, flip +inf).
-            let candidate_table_refs: Vec<Option<String>> = std::iter::once(None)
-                .chain(candidates.iter().map(|(_, r, _)| Some(r.to_string())))
-                .collect();
-            let candidate_file_counts: Vec<Option<usize>> = std::iter::once(None)
-                .chain(candidates.iter().map(|(_, _, fc)| *fc))
-                .collect();
-            let branches: Vec<LogicalPlan> = std::iter::once(node)
-                .chain(candidates.into_iter().map(|(lp, _, _)| lp))
-                .collect();
+            // Build (LP, table_ref, file_count) triples: base is `None`, MV candidates
+            // carry their identity + populated-ness. We then sort in place using the
+            // SAME comparator `OneOf::inputs()` uses, so that:
+            //   * `self.branches` order matches `inputs()` order (sort becomes a no-op),
+            //   * `candidate_table_refs[i]` / `candidate_file_counts[i]` remain aligned
+            //     with the physical candidate the planner ultimately hands to the cost
+            //     function.
+            // Without this pre-sort, the metadata would stay in construction order
+            // while `inputs()` reorders the branches, silently misattributing MV
+            // identity/file_count → cost function misclassifies EmptyExec candidates
+            // (X-3269 populated-pruned MV loses, or X-2174 unpopulated MV wrongly wins).
+            let mut aligned: Vec<(LogicalPlan, Option<String>, Option<usize>)> =
+                std::iter::once((node, None, None))
+                    .chain(
+                        candidates
+                            .into_iter()
+                            .map(|(lp, r, fc)| (lp, Some(r.to_string()), fc)),
+                    )
+                    .collect();
+            aligned.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+            let branches: Vec<LogicalPlan> = aligned.iter().map(|(lp, _, _)| lp.clone()).collect();
+            let candidate_table_refs: Vec<Option<String>> =
+                aligned.iter().map(|(_, r, _)| r.clone()).collect();
+            let candidate_file_counts: Vec<Option<usize>> =
+                aligned.into_iter().map(|(_, _, fc)| fc).collect();
             Ok(Transformed::new(
                 LogicalPlan::Extension(Extension {
                     node: Arc::new(OneOf::with_rewrite_context(
@@ -881,5 +890,93 @@ mod tests_rewrite_context {
             .expect("expected OneOfExec");
 
         assert_eq!(rebuilt.rewrite_context(), &context);
+    }
+
+    #[test]
+    fn rewrite_context_defaults_candidate_lists_to_empty() {
+        // `RewriteContext::new` must leave the new per-branch lists empty so any
+        // caller that pre-dates the X-3269 threading keeps its original behaviour
+        // (downstream discriminators fall back to their existing signals when the
+        // slice is empty).
+        let ctx = RewriteContext::new(vec!["catalog.schema.root".to_string()]);
+        assert!(ctx.candidate_table_refs().is_empty());
+        assert!(ctx.candidate_file_counts().is_empty());
+    }
+
+    #[test]
+    fn rewrite_context_builders_attach_candidate_metadata() {
+        let ctx = RewriteContext::new(vec!["catalog.schema.root".to_string()])
+            .with_candidate_table_refs(vec![
+                None,
+                Some("catalog.schema.mv_a".to_string()),
+                Some("catalog.schema.mv_b".to_string()),
+            ])
+            .with_candidate_file_counts(vec![None, Some(0), Some(100)]);
+
+        assert_eq!(
+            ctx.candidate_table_refs(),
+            &[
+                None,
+                Some("catalog.schema.mv_a".to_string()),
+                Some("catalog.schema.mv_b".to_string()),
+            ]
+        );
+        assert_eq!(ctx.candidate_file_counts(), &[None, Some(0), Some(100)]);
+    }
+
+    #[test]
+    fn one_of_branches_and_candidate_metadata_share_ordering() {
+        // Invariant: whatever ordering `OneOf::inputs()` exposes to the DataFusion
+        // planner (and therefore to `plan_extension`'s `physical_inputs`), the
+        // `candidate_table_refs` / `candidate_file_counts` slices must line up.
+        // `ViewMatchingRewriter::f_down` pre-sorts branches + metadata together so
+        // `inputs()`'s sort is a no-op; this test guards that invariant from
+        // regressing (e.g. by someone appending metadata after the sort or by
+        // `inputs()` gaining a different comparator).
+        use itertools::Itertools;
+
+        let base = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let candidate_a = LogicalPlanBuilder::empty(true)
+            .build()
+            .expect("candidate a plan");
+        // Assemble in a deliberately non-sorted order so we exercise the invariant.
+        let mut aligned: Vec<(LogicalPlan, Option<String>, Option<usize>)> = vec![
+            (
+                candidate_a.clone(),
+                Some("catalog.schema.mv_a".to_string()),
+                Some(42),
+            ),
+            (base.clone(), None, None),
+        ];
+        aligned.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        let branches: Vec<LogicalPlan> = aligned.iter().map(|(lp, _, _)| lp.clone()).collect();
+        let refs: Vec<Option<String>> = aligned.iter().map(|(_, r, _)| r.clone()).collect();
+        let counts: Vec<Option<usize>> = aligned.iter().map(|(_, _, fc)| *fc).collect();
+
+        let one_of = OneOf::with_rewrite_context(
+            branches.clone(),
+            RewriteContext::new(vec!["catalog.schema.root".to_string()])
+                .with_candidate_table_refs(refs.clone())
+                .with_candidate_file_counts(counts.clone()),
+        );
+
+        // Simulate the planner call: `inputs()` returns the branches in sort order.
+        let inputs_order: Vec<&LogicalPlan> = UserDefinedLogicalNodeCore::inputs(&one_of)
+            .into_iter()
+            .collect_vec();
+
+        // Because the pre-sort in the rewriter matches the sort inside inputs(), the
+        // exposed branch order must equal the stored branch order — index i in
+        // `inputs()` corresponds to index i in the metadata vectors.
+        for (i, exposed) in inputs_order.iter().enumerate() {
+            assert_eq!(
+                *exposed, &branches[i],
+                "OneOf::inputs()[{i}] must match self.branches[{i}] for metadata to stay aligned"
+            );
+        }
+        assert_eq!(one_of.rewrite_context().candidate_table_refs(), refs);
+        assert_eq!(one_of.rewrite_context().candidate_file_counts(), counts);
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -72,6 +72,12 @@ use super::QueryRewriteOptions;
 /// Per-branch metadata inside a `OneOf` / `OneOfExec`. One variant per branch,
 /// aligned by index with the containing `branches` / `candidates` vector.
 ///
+/// Lifecycle judgement (populated / unpopulated / stale / ...) is made upstream
+/// by [`ViewMatchingRewriter`] via
+/// [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness):
+/// `NotReady` MVs never reach the candidate set at all, so any
+/// `Materialized` variant that shows up here is safe to route queries to.
+///
 /// The invariant enforced at construction (see `ViewMatchingRewriter::f_down`):
 ///
 /// * Index 0 is always [`CandidateMetadata::Base`] — the query's original LP,
@@ -89,22 +95,13 @@ use super::QueryRewriteOptions;
 pub enum CandidateMetadata {
     /// The query's original branch (index 0 in every OneOf).
     Base,
-    /// A materialized-view rewrite of the query.
+    /// A materialized-view rewrite of the query. Only MVs that reported
+    /// `Ready` or `Unknown` readiness reach this state; `NotReady` MVs
+    /// are filtered upstream by [`ViewMatchingRewriter`].
     Materialized {
         /// Registered `TableReference` of the source MV. Stable across
         /// LP transformations; safe to use as a sort key.
         table_ref: String,
-        /// Total file count of the MV at LP-rewrite time, snapshotted from
-        /// [`Materialized::file_count()`](crate::materialized::Materialized::file_count).
-        ///
-        /// * `None` — provider doesn't expose file_count.
-        /// * `Some(0)` — MV is registered but not populated (e.g. newly-deployed
-        ///   MV whose ingest task hasn't run yet). Cost functions should
-        ///   reject it so an empty answer doesn't silently win.
-        /// * `Some(n)` — MV is populated. If the physical plan collapsed to
-        ///   an `EmptyExec`, that's predicate-pruning (should win via `-inf`
-        ///   cost), not an unpopulated MV.
-        file_count: Option<usize>,
     },
 }
 
@@ -325,41 +322,46 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             Ok(form) => form,
         };
 
-        // Generate candidate substitutions. Track (source MV TableReference, source MV
-        // total file count) alongside each rewritten LP so we can propagate per-branch
-        // identity + populated-ness into `RewriteContext`. Cost functions need both
-        // signals so they can tell an unpopulated MV (`file_count == 0`, must lose)
-        // apart from a populated MV whose physical plan collapsed to `EmptyExec`
-        // through predicate pruning (`file_count > 0`, should win).
-        let candidates: Vec<(LogicalPlan, TableReference, Option<usize>)> = self
+        // Generate candidate substitutions, filtering out MVs that report
+        // `NotReady` upstream so unpopulated / in-flight MVs never reach the
+        // cost function. Lifecycle correctness lives in the provider (see
+        // `Materialized::rewrite_readiness`); the cost function then only
+        // sees candidates it can safely route queries to.
+        let candidates: Vec<(LogicalPlan, TableReference)> = self
             .parent
             .mv_plans
             .iter()
             .filter_map(|(table_ref, (table, plan))| {
                 // Only attempt rewrite if the view references our table in the first place
-                plan.referenced_tables()
-                    .contains(&table_reference)
-                    .then(|| {
-                        let file_count = cast_to_materialized(table.as_ref())
-                            .ok()
-                            .flatten()
-                            .and_then(|mv| mv.file_count());
-                        form.rewrite_from(
-                            plan,
-                            table_ref.clone(),
-                            provider_as_source(Arc::clone(table)),
-                        )
-                        .transpose()
-                        .map(|res| res.map(|lp| (lp, table_ref.clone(), file_count)))
-                    })
+                if !plan.referenced_tables().contains(&table_reference) {
+                    return None;
+                }
+                // Drop `NotReady` MVs upfront. `Ready` and `Unknown` both pass
+                // through — `Unknown` is the trait default, so we don't break
+                // pre-existing providers that don't distinguish lifecycle states.
+                let readiness = cast_to_materialized(table.as_ref())
+                    .ok()
                     .flatten()
+                    .map(|mv| mv.rewrite_readiness())
+                    .unwrap_or(crate::materialized::RewriteReadiness::Unknown);
+                if matches!(readiness, crate::materialized::RewriteReadiness::NotReady) {
+                    log::trace!("skipping NotReady MV: {table_ref}");
+                    return None;
+                }
+                form.rewrite_from(
+                    plan,
+                    table_ref.clone(),
+                    provider_as_source(Arc::clone(table)),
+                )
+                .transpose()
+                .map(|res| res.map(|lp| (lp, table_ref.clone())))
             })
             .flat_map(|res| match res {
                 Err(e) => {
                     log::trace!("error rewriting: {e}");
                     None
                 }
-                Ok(triple) => Some(triple),
+                Ok(pair) => Some(pair),
             })
             .collect();
 
@@ -385,13 +387,12 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             candidates.sort_by(|a, b| a.1.to_string().cmp(&b.1.to_string()));
 
             let branches: Vec<LogicalPlan> = std::iter::once(node)
-                .chain(candidates.iter().map(|(lp, _, _)| lp.clone()))
+                .chain(candidates.iter().map(|(lp, _)| lp.clone()))
                 .collect();
             let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
-                .chain(candidates.into_iter().map(|(_, table_ref, file_count)| {
+                .chain(candidates.into_iter().map(|(_, table_ref)| {
                     CandidateMetadata::Materialized {
                         table_ref: table_ref.to_string(),
-                        file_count,
                     }
                 }))
                 .collect();
@@ -938,11 +939,9 @@ mod tests_rewrite_context {
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
                     table_ref: "catalog.schema.mv_a".to_string(),
-                    file_count: Some(0),
                 },
                 CandidateMetadata::Materialized {
                     table_ref: "catalog.schema.mv_b".to_string(),
-                    file_count: Some(100),
                 },
             ]);
 
@@ -953,14 +952,12 @@ mod tests_rewrite_context {
             cands[1],
             CandidateMetadata::Materialized {
                 ref table_ref,
-                file_count: Some(0),
             } if table_ref == "catalog.schema.mv_a"
         ));
         assert!(matches!(
             cands[2],
             CandidateMetadata::Materialized {
                 ref table_ref,
-                file_count: Some(100),
             } if table_ref == "catalog.schema.mv_b"
         ));
     }
@@ -990,7 +987,6 @@ mod tests_rewrite_context {
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
                     table_ref: "catalog.schema.mv_a".to_string(),
-                    file_count: Some(42),
                 },
             ]),
         );
@@ -1048,7 +1044,6 @@ mod tests_rewrite_context {
 
         let mv_meta = CandidateMetadata::Materialized {
             table_ref: "catalog.schema.mv_a".to_string(),
-            file_count: Some(2_090_783_849),
         };
         let one_of = OneOf::with_rewrite_context(
             vec![base.clone(), candidate.clone()],
@@ -1076,7 +1071,7 @@ mod tests_rewrite_context {
             "OneOf::schema() must still resolve to the base branch schema"
         );
         // Metadata still aligned: index 0 = Base, index 1 = the same MV
-        // identity/file_count even though its LP changed.
+        // identity even though its LP changed.
         assert_eq!(rebuilt.rewrite_context().candidates().len(), 2);
         assert!(matches!(
             rebuilt.rewrite_context().candidates()[0],
@@ -1087,5 +1082,64 @@ mod tests_rewrite_context {
         let exposed = UserDefinedLogicalNodeCore::inputs(&rebuilt);
         assert_eq!(*exposed[0], base);
         assert_eq!(*exposed[1], rewritten_candidate);
+    }
+
+    #[test]
+    fn multi_mv_candidates_sort_lexicographically_by_table_ref() {
+        // `f_down` sorts MVs by `TableReference` (transformation-invariant).
+        // We reproduce the ordering step here with three candidates whose
+        // table_refs are deliberately in reverse-lex order to prove the sort
+        // brings them into canonical `mv_a < mv_b < mv_c` sequence, with
+        // the base still pinned at index 0.
+        let base = LogicalPlanBuilder::empty(false)
+            .build()
+            .expect("empty base plan");
+        let mv_a_lp = LogicalPlanBuilder::empty(true).build().expect("mv_a plan");
+        let mv_b_lp = LogicalPlanBuilder::empty(true).build().expect("mv_b plan");
+        let mv_c_lp = LogicalPlanBuilder::empty(true).build().expect("mv_c plan");
+
+        // Deliberately non-sorted insertion order (as would happen with
+        // `mv_plans` HashMap iteration).
+        let mut candidates: Vec<(LogicalPlan, TableReference)> = vec![
+            (mv_c_lp.clone(), TableReference::bare("catalog.schema.mv_c")),
+            (mv_a_lp.clone(), TableReference::bare("catalog.schema.mv_a")),
+            (mv_b_lp.clone(), TableReference::bare("catalog.schema.mv_b")),
+        ];
+        candidates.sort_by(|a, b| a.1.to_string().cmp(&b.1.to_string()));
+
+        // Base first, then sorted MVs.
+        let branches: Vec<LogicalPlan> = std::iter::once(base.clone())
+            .chain(candidates.iter().map(|(lp, _)| lp.clone()))
+            .collect();
+        let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
+            .chain(
+                candidates
+                    .into_iter()
+                    .map(|(_, r)| CandidateMetadata::Materialized {
+                        table_ref: r.to_string(),
+                    }),
+            )
+            .collect();
+
+        assert_eq!(branches[0], base, "index 0 must be base");
+        // MVs land in lex order regardless of insertion order.
+        assert_eq!(
+            metadata[1],
+            CandidateMetadata::Materialized {
+                table_ref: "catalog.schema.mv_a".to_string()
+            }
+        );
+        assert_eq!(
+            metadata[2],
+            CandidateMetadata::Materialized {
+                table_ref: "catalog.schema.mv_b".to_string()
+            }
+        );
+        assert_eq!(
+            metadata[3],
+            CandidateMetadata::Materialized {
+                table_ref: "catalog.schema.mv_c".to_string()
+            }
+        );
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -225,6 +225,19 @@ impl ViewMatcher {
         &self.mv_plans
     }
 
+    /// Test-only constructor that skips the full `try_new_from_state` catalog
+    /// walk and takes a pre-built `mv_plans` HashMap directly. Used by unit
+    /// tests that need to drive `ViewMatchingRewriter` without setting up a
+    /// SessionContext / SchemaProvider — e.g. tests that inject mock
+    /// `Materialized` providers with a specific `rewrite_readiness()` value
+    /// to assert the upstream filter.
+    #[cfg(test)]
+    pub(crate) fn from_mv_plans_for_test(
+        mv_plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)>,
+    ) -> Self {
+        Self { mv_plans }
+    }
+
     /// Returns materialized views that potentially reference the given table.
     ///
     /// This is a preliminary filter - it only checks if the MV references the table
@@ -1140,6 +1153,214 @@ mod tests_rewrite_context {
             CandidateMetadata::Materialized {
                 table_ref: "catalog.schema.mv_c".to_string()
             }
+        );
+    }
+}
+
+/// End-to-end coverage for `ViewMatchingRewriter::f_down`'s `NotReady`
+/// filter. Uses a `MockMv` provider whose `rewrite_readiness()` return
+/// value is set per-instance so a single test can register three MVs —
+/// one Ready, one NotReady, one Unknown — and assert the rewriter drops
+/// only the NotReady one.
+#[cfg(test)]
+mod tests_view_matcher_readiness_filter {
+    use super::*;
+    use crate::materialized::{ListingTableLike, Materialized, RewriteReadiness};
+    use crate::rewrite::normal_form::SpjNormalForm;
+    use arrow_schema::{DataType, Field, Schema, SchemaRef};
+    use datafusion::catalog::{Session, TableProvider};
+    use datafusion::datasource::listing::ListingTableUrl;
+    use datafusion::datasource::TableType;
+    use datafusion_common::Result;
+    use datafusion_expr::builder::LogicalTableSource;
+    use datafusion_expr::{Expr, LogicalPlan, LogicalPlanBuilder};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    /// Mock Materialized provider with a caller-selectable readiness value.
+    /// The `query` is a trivial `TableScan(source_table)` so the rewriter's
+    /// `SpjNormalForm` handling can trivially match a base LP against it.
+    #[derive(Debug)]
+    struct MockMv {
+        source_table: String,
+        query: LogicalPlan,
+        readiness: RewriteReadiness,
+    }
+
+    impl MockMv {
+        fn new(source_table: &str, readiness: RewriteReadiness) -> Arc<Self> {
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+            let source = Arc::new(LogicalTableSource::new(schema));
+            let query = LogicalPlanBuilder::scan(source_table, source, None)
+                .expect("scan builder")
+                .build()
+                .expect("build MV query");
+            Arc::new(Self {
+                source_table: source_table.to_string(),
+                query,
+                readiness,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl TableProvider for MockMv {
+        fn schema(&self) -> SchemaRef {
+            Arc::new(self.query.schema().as_arrow().clone())
+        }
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+        async fn scan(
+            &self,
+            _state: &dyn Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            unimplemented!("MockMv::scan is not exercised by these tests")
+        }
+    }
+
+    impl ListingTableLike for MockMv {
+        fn table_paths(&self) -> Vec<ListingTableUrl> {
+            vec![
+                ListingTableUrl::parse(format!("mem:///{}", self.source_table)).expect("parse url"),
+            ]
+        }
+        fn partition_columns(&self) -> Vec<String> {
+            Vec::new()
+        }
+        fn file_ext(&self) -> String {
+            String::new()
+        }
+    }
+
+    impl Materialized for MockMv {
+        fn query(&self) -> LogicalPlan {
+            self.query.clone()
+        }
+        fn rewrite_readiness(&self) -> RewriteReadiness {
+            self.readiness
+        }
+    }
+
+    /// Build a `ViewMatcher` whose `mv_plans` HashMap contains three MVs, all
+    /// covering the same source table, one per readiness variant. The MV
+    /// registered keys use the readiness name so tests can identify which
+    /// candidates survived by their `TableReference`.
+    fn build_matcher_with_three_readiness_states(source_table: &str) -> ViewMatcher {
+        crate::materialized::register_materialized::<MockMv>();
+        let mut plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)> =
+            HashMap::new();
+        for (name, readiness) in [
+            ("mv_ready", RewriteReadiness::Ready),
+            ("mv_not_ready", RewriteReadiness::NotReady),
+            ("mv_unknown", RewriteReadiness::Unknown),
+        ] {
+            let mv = MockMv::new(source_table, readiness);
+            let form = SpjNormalForm::new(&mv.query).expect("MV LP is a valid SPJ");
+            plans.insert(
+                TableReference::bare(name),
+                (mv.clone() as Arc<dyn TableProvider>, form),
+            );
+        }
+        ViewMatcher::from_mv_plans_for_test(plans)
+    }
+
+    /// Drive `ViewMatchingRewriter` over a `TableScan(source_table)` LP and
+    /// return the rewritten plan.
+    fn rewrite_scan_lp(matcher: &ViewMatcher, source_table: &str) -> LogicalPlan {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let source = Arc::new(LogicalTableSource::new(schema));
+        let query = LogicalPlanBuilder::scan(source_table, source, None)
+            .expect("scan builder")
+            .build()
+            .expect("build query LP");
+
+        query
+            .rewrite(&mut ViewMatchingRewriter { parent: matcher })
+            .expect("rewrite scan")
+            .data
+    }
+
+    fn candidate_table_refs(plan: &LogicalPlan) -> Vec<String> {
+        let LogicalPlan::Extension(ext) = plan else {
+            panic!("expected OneOf extension, got {plan:?}");
+        };
+        let one_of = ext
+            .node
+            .as_any()
+            .downcast_ref::<OneOf>()
+            .expect("OneOf node");
+        one_of
+            .rewrite_context()
+            .candidates()
+            .iter()
+            .filter_map(|c| match c {
+                CandidateMetadata::Materialized { table_ref } => Some(table_ref.clone()),
+                CandidateMetadata::Base => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn f_down_excludes_not_ready_and_admits_ready_and_unknown() {
+        let matcher = build_matcher_with_three_readiness_states("target_t");
+        let rewritten = rewrite_scan_lp(&matcher, "target_t");
+
+        let mv_refs = candidate_table_refs(&rewritten);
+        // Ready + Unknown survive, NotReady is dropped.
+        assert!(
+            mv_refs.iter().any(|r| r == "mv_ready"),
+            "Ready MV must be a candidate. got={mv_refs:?}"
+        );
+        assert!(
+            mv_refs.iter().any(|r| r == "mv_unknown"),
+            "Unknown MV must be a candidate. got={mv_refs:?}"
+        );
+        assert!(
+            mv_refs.iter().all(|r| r != "mv_not_ready"),
+            "NotReady MV must be filtered out. got={mv_refs:?}"
+        );
+
+        // Base is always index 0.
+        let LogicalPlan::Extension(ext) = &rewritten else {
+            panic!("expected Extension");
+        };
+        let one_of = ext
+            .node
+            .as_any()
+            .downcast_ref::<OneOf>()
+            .expect("OneOf node");
+        assert!(matches!(
+            one_of.rewrite_context().candidates()[0],
+            CandidateMetadata::Base
+        ));
+    }
+
+    #[test]
+    fn f_down_returns_original_lp_when_every_mv_is_not_ready() {
+        // Register only a NotReady MV — the rewriter must fall through and
+        // return the original scan unchanged, not wrap it in a candidate-less
+        // OneOf.
+        crate::materialized::register_materialized::<MockMv>();
+        let mut plans: HashMap<TableReference, (Arc<dyn TableProvider>, SpjNormalForm)> =
+            HashMap::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::NotReady);
+        let form = SpjNormalForm::new(&mv.query).expect("valid SPJ");
+        plans.insert(
+            TableReference::bare("mv_not_ready_only"),
+            (mv as Arc<dyn TableProvider>, form),
+        );
+        let matcher = ViewMatcher::from_mv_plans_for_test(plans);
+
+        let rewritten = rewrite_scan_lp(&matcher, "target_t");
+
+        // No OneOf wrapper — plan is the plain TableScan.
+        assert!(
+            !matches!(&rewritten, LogicalPlan::Extension(ext) if ext.node.as_any().is::<OneOf>()),
+            "no candidate MV survived, so the rewriter must return the base LP untouched. got={rewritten:?}"
         );
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -73,12 +73,12 @@ use super::QueryRewriteOptions;
 /// aligned by index with the containing `branches` / `candidates` vector.
 ///
 /// Lifecycle judgement (populated / unpopulated / stale / ...) is made upstream
-/// by [`ViewMatchingRewriter`] via
+/// by [`ViewMatcher`] via
 /// [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness):
 /// `NotReady` MVs never reach the candidate set at all, so any
 /// `Materialized` variant that shows up here is safe to route queries to.
 ///
-/// The invariant enforced at construction (see `ViewMatchingRewriter::f_down`):
+/// The invariant enforced at construction inside [`ViewMatcher`]:
 ///
 /// * Index 0 is always [`CandidateMetadata::Base`] — the query's original LP,
 ///   with no MV rewrite applied. `OneOf::schema()` reads `branches[0].schema()`
@@ -97,7 +97,7 @@ pub enum CandidateMetadata {
     Base,
     /// A materialized-view rewrite of the query. Only MVs that reported
     /// `Ready` or `Unknown` readiness reach this state; `NotReady` MVs
-    /// are filtered upstream by [`ViewMatchingRewriter`].
+    /// are filtered upstream by [`ViewMatcher`].
     Materialized {
         /// Registered `TableReference` of the source MV. Stable across
         /// LP transformations; safe to use as a sort key.
@@ -352,11 +352,24 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
                 // Drop `NotReady` MVs upfront. `Ready` and `Unknown` both pass
                 // through — `Unknown` is the trait default, so we don't break
                 // pre-existing providers that don't distinguish lifecycle states.
-                let readiness = cast_to_materialized(table.as_ref())
-                    .ok()
-                    .flatten()
-                    .map(|mv| mv.rewrite_readiness())
-                    .unwrap_or(crate::materialized::RewriteReadiness::Unknown);
+                //
+                // A `cast_to_materialized` error means the provider violates a
+                // `Materialized` invariant (e.g. static partition columns not a
+                // prefix). Surface it in the log rather than silently defaulting
+                // to `Unknown` so catalog issues stay debuggable, then treat the
+                // MV as Unknown (the pre-existing "include as candidate, cost
+                // function decides" default) so the rewrite path keeps functioning.
+                let readiness = match cast_to_materialized(table.as_ref()) {
+                    Ok(Some(mv)) => mv.rewrite_readiness(),
+                    Ok(None) => crate::materialized::RewriteReadiness::Unknown,
+                    Err(e) => {
+                        log::warn!(
+                            "cast_to_materialized failed for {table_ref}: {e}; \
+                             treating as Unknown readiness"
+                        );
+                        crate::materialized::RewriteReadiness::Unknown
+                    }
+                };
                 if matches!(readiness, crate::materialized::RewriteReadiness::NotReady) {
                     log::trace!("skipping NotReady MV: {table_ref}");
                     return None;

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -67,12 +67,13 @@ use ordered_float::OrderedFloat;
 use crate::materialized::cast_to_materialized;
 
 use super::normal_form::SpjNormalForm;
+use super::readiness::{drop_not_ready_after_refresh, refresh_candidate_readiness};
 use super::QueryRewriteOptions;
 
-// Bring readiness types in for use inside this module AND re-export
-// them for backward compatibility. Callers that used to import from
-// `crate::rewrite::exploitation` (the pre-move location) keep working;
-// the canonical home is now `crate::rewrite::readiness`.
+// Re-export readiness types for backward compatibility. Callers that
+// used to import from `crate::rewrite::exploitation` (the pre-move
+// location) keep working; the canonical home is now
+// `crate::rewrite::readiness`.
 pub use super::readiness::{
     readiness_from_plan, CandidateMetadata, ReadinessAnnotatedExec, RewriteReadiness,
 };
@@ -539,163 +540,6 @@ impl ExtensionPlanner for ViewExploitationPlanner {
             Arc::clone(&self.cost),
             filtered_context,
         )?)))
-    }
-}
-
-/// Pair-wise filter that drops every `Materialized` candidate whose
-/// refreshed readiness is `NotReady`, along with its aligned entry in
-/// `physical_inputs`. Base is never filtered.
-///
-/// If `candidates` is empty or is not aligned with `physical_inputs`
-/// (older callsites that constructed the `OneOf` without per-branch
-/// metadata, or a caller that supplied a mismatched vector), the inputs
-/// are passed through unchanged and the metadata is dropped entirely —
-/// preserving a misaligned slice would let it flow into `OneOfExec` and
-/// attribute readiness to the wrong branch inside the cost function.
-/// Callsites without metadata keep their original behaviour (the empty
-/// slice is what the pre-readiness code path also carried).
-fn drop_not_ready_after_refresh(
-    physical_inputs: &[Arc<dyn ExecutionPlan>],
-    candidates: &[CandidateMetadata],
-) -> (Vec<Arc<dyn ExecutionPlan>>, Vec<CandidateMetadata>) {
-    if candidates.len() != physical_inputs.len() {
-        return (physical_inputs.to_vec(), Vec::new());
-    }
-    let mut kept_inputs = Vec::with_capacity(physical_inputs.len());
-    let mut kept_candidates = Vec::with_capacity(candidates.len());
-    for (input, cand) in physical_inputs.iter().zip(candidates.iter()) {
-        let drop = matches!(
-            cand,
-            CandidateMetadata::Materialized {
-                readiness: RewriteReadiness::NotReady,
-                ..
-            }
-        );
-        if drop {
-            continue;
-        }
-        kept_inputs.push(Arc::clone(input));
-        kept_candidates.push(cand.clone());
-    }
-    (kept_inputs, kept_candidates)
-}
-
-/// Re-consult every `Materialized` candidate's `rewrite_readiness()` and
-/// return a `RewriteContext` whose metadata reflects the current values.
-///
-/// Called from `ViewExploitationPlanner::plan_extension` once
-/// physical inputs have been planned (i.e. after `TableProvider::scan()`
-/// has run on every candidate branch). Providers whose readiness only
-/// becomes definite after scan initialization (lazy indexes, warmup jobs,
-/// snapshot swaps that happen inside `scan`) surface their new value here
-/// so the cost function sees the definitive readiness rather than the
-/// stale LP-time snapshot.
-///
-/// For each `Materialized` candidate the refresh prefers the atomic
-/// readiness captured at scan time (via `ReadinessAnnotatedExec` in the
-/// candidate's `physical_input`) over racy re-sampling. Providers that
-/// haven't opted into the wrapper fall back to sampling the current
-/// `rewrite_readiness()` through the catalog — this is best-effort and
-/// can be stale under concurrent snapshot swaps (see `ReadinessAnnotatedExec`).
-///
-/// Lookup failures on the fallback path (table not found in the
-/// catalog, provider is no longer a `Materialized`, `cast_to_materialized`
-/// error) preserve the LP-time value — never downgrade what we already
-/// observed.
-async fn refresh_candidate_readiness(
-    context: RewriteContext,
-    physical_inputs: &[Arc<dyn ExecutionPlan>],
-    session_state: &SessionState,
-) -> RewriteContext {
-    let catalog_list = session_state.catalog_list();
-    let default_catalog = &session_state.config().options().catalog.default_catalog;
-    let default_schema = &session_state.config().options().catalog.default_schema;
-
-    let candidates = context.candidates();
-    // Alignment-tolerant zipping: if a caller supplied metadata whose
-    // length differs from `physical_inputs`, we can't safely pair them,
-    // so we skip the annotated lookup for the misaligned indices. The
-    // downstream `drop_not_ready_after_refresh` filter handles the same
-    // case defensively.
-    let aligned = candidates.len() == physical_inputs.len();
-
-    let refreshed: Vec<CandidateMetadata> =
-        futures::future::join_all(candidates.iter().enumerate().map(|(idx, c)| async move {
-            match c {
-                CandidateMetadata::Base => CandidateMetadata::Base,
-                CandidateMetadata::Materialized {
-                    table_ref,
-                    readiness,
-                } => {
-                    // Prefer atomically-captured readiness from the physical
-                    // input over sampling — closes the race between the
-                    // snapshot scan read from and the current provider state.
-                    let annotated = if aligned {
-                        readiness_from_plan(&physical_inputs[idx])
-                    } else {
-                        None
-                    };
-
-                    let new_readiness = match annotated {
-                        Some(r) => r,
-                        None => resolve_current_readiness(
-                            catalog_list.as_ref(),
-                            default_catalog,
-                            default_schema,
-                            table_ref,
-                        )
-                        .await
-                        .unwrap_or(*readiness),
-                    };
-
-                    CandidateMetadata::Materialized {
-                        table_ref: table_ref.clone(),
-                        readiness: new_readiness,
-                    }
-                }
-            }
-        }))
-        .await;
-
-    context.with_candidates(refreshed)
-}
-
-/// Resolve `table_ref` through the catalog list and re-consult the
-/// provider's `rewrite_readiness()`. Returns `None` on any lookup failure
-/// so the caller can fall back to the LP-time value.
-async fn resolve_current_readiness(
-    catalog_list: &dyn datafusion::catalog::CatalogProviderList,
-    default_catalog: &str,
-    default_schema: &str,
-    table_ref: &TableReference,
-) -> Option<RewriteReadiness> {
-    // Resolve the (possibly bare or partial) reference against the
-    // session's default catalog/schema without ever going through
-    // `Display`/`parse_str`, which is not lossless for quoted or dotted
-    // identifiers.
-    let resolved = table_ref.clone().resolve(default_catalog, default_schema);
-    let catalog = catalog_list.catalog(resolved.catalog.as_ref())?;
-    let schema = catalog.schema(resolved.schema.as_ref())?;
-    let table = match schema.table(resolved.table.as_ref()).await {
-        Ok(Some(t)) => t,
-        Ok(None) => {
-            log::trace!("refresh_candidate_readiness: no table {table_ref} in catalog");
-            return None;
-        }
-        Err(e) => {
-            log::warn!("refresh_candidate_readiness: catalog lookup failed for {table_ref}: {e}");
-            return None;
-        }
-    };
-    match cast_to_materialized(table.as_ref()) {
-        Ok(Some(mv)) => Some(mv.rewrite_readiness()),
-        Ok(None) => None,
-        Err(e) => {
-            log::warn!(
-                "refresh_candidate_readiness: cast_to_materialized failed for {table_ref}: {e}"
-            );
-            None
-        }
     }
 }
 

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -85,11 +85,12 @@ pub struct RewriteContext {
     /// time from `Materialized::file_count()`. Aligned with `candidate_table_refs`.
     ///
     /// * `None` — base branch, or a candidate whose provider doesn't expose file_count
-    /// * `Some(0)` — MV is registered but has no files (X-2174 case: newly-deployed MV
-    ///   whose ingest task hasn't run yet — cost function should reject it)
-    /// * `Some(n)` — MV is populated with `n` files (X-3269 case: if the physical plan
-    ///   collapsed to EmptyExec, that's predicate-pruning, not an unpopulated MV, so the
-    ///   cost function should keep the `-inf` cost and let the MV win)
+    /// * `Some(0)` — MV is registered but has no files (e.g. newly-deployed MV whose
+    ///   ingest task hasn't run yet); cost functions should reject it so a query
+    ///   isn't silently answered with an empty result
+    /// * `Some(n)` — MV is populated with `n` files; if the physical plan collapsed
+    ///   to `EmptyExec`, that's predicate-pruning rather than an unpopulated MV, so
+    ///   the cost function should keep the `-inf` cost and let the MV win
     candidate_file_counts: Vec<Option<usize>>,
 }
 
@@ -123,7 +124,8 @@ impl RewriteContext {
     }
 
     /// Returns the per-branch source table refs, aligned with the candidate plan order.
-    /// Empty when no callsite has attached them (backward compatible with pre-X-3269 usage).
+    /// Empty when no callsite has attached them (backward compatible with callers
+    /// that pre-date the per-branch metadata extensions).
     pub fn candidate_table_refs(&self) -> &[Option<String>] {
         &self.candidate_table_refs
     }
@@ -313,8 +315,9 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
         // Generate candidate substitutions. Track (source MV TableReference, source MV
         // total file count) alongside each rewritten LP so we can propagate per-branch
         // identity + populated-ness into `RewriteContext`. Cost functions need both
-        // signals: file_count == 0 → unpopulated MV (X-2174 protection), file_count > 0 +
-        // physical plan collapsed to EmptyExec → predicate-pruned (X-3269 fix).
+        // signals so they can tell an unpopulated MV (`file_count == 0`, must lose)
+        // apart from a populated MV whose physical plan collapsed to `EmptyExec`
+        // through predicate pruning (`file_count > 0`, should win).
         let candidates: Vec<(LogicalPlan, TableReference, Option<usize>)> = self
             .parent
             .mv_plans
@@ -360,8 +363,8 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             //     function.
             // Without this pre-sort, the metadata would stay in construction order
             // while `inputs()` reorders the branches, silently misattributing MV
-            // identity/file_count → cost function misclassifies EmptyExec candidates
-            // (X-3269 populated-pruned MV loses, or X-2174 unpopulated MV wrongly wins).
+            // identity/file_count to the wrong candidate — a populated pruned MV
+            // could lose, or an unpopulated MV could wrongly win.
             let mut aligned: Vec<(LogicalPlan, Option<String>, Option<usize>)> =
                 std::iter::once((node, None, None))
                     .chain(
@@ -895,9 +898,9 @@ mod tests_rewrite_context {
     #[test]
     fn rewrite_context_defaults_candidate_lists_to_empty() {
         // `RewriteContext::new` must leave the new per-branch lists empty so any
-        // caller that pre-dates the X-3269 threading keeps its original behaviour
-        // (downstream discriminators fall back to their existing signals when the
-        // slice is empty).
+        // caller that pre-dates the per-branch metadata extensions keeps its
+        // original behaviour (downstream discriminators fall back to their
+        // existing signals when the slice is empty).
         let ctx = RewriteContext::new(vec!["catalog.schema.root".to_string()]);
         assert!(ctx.candidate_table_refs().is_empty());
         assert!(ctx.candidate_file_counts().is_empty());

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -115,9 +115,12 @@ pub enum CandidateMetadata {
     /// silently treated as `Ready`, since that would regress providers
     /// that haven't declared a lifecycle.
     Materialized {
-        /// Registered `TableReference` of the source MV. Stable across
-        /// LP transformations; safe to use as a sort key.
-        table_ref: String,
+        /// Registered `TableReference` of the source MV. Stored directly
+        /// rather than as `.to_string()` so identifiers with dots or
+        /// quoting round-trip losslessly through the physical-time
+        /// catalog resolution. Stable across LP transformations; safe to
+        /// use as a sort key.
+        table_ref: TableReference,
         /// Provider readiness as observed at physical-planning time — i.e.
         /// after DataFusion has invoked `TableProvider::scan()` on this
         /// branch. Set once at LP rewrite from the provider's initial
@@ -453,7 +456,7 @@ impl TreeNodeRewriter for ViewMatchingRewriter<'_> {
             let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
                 .chain(candidates.into_iter().map(|(_, table_ref, readiness)| {
                     CandidateMetadata::Materialized {
-                        table_ref: table_ref.to_string(),
+                        table_ref,
                         readiness,
                     }
                 }))
@@ -560,8 +563,12 @@ impl ExtensionPlanner for ViewExploitationPlanner {
         // stale by now — re-consulting the provider here gives the definitive
         // value the cost function should see. See PR #55 review discussion for
         // the lazy-index cold-start scenario this addresses.
-        let refreshed_context =
-            refresh_candidate_readiness(one_of.rewrite_context().clone(), session_state).await;
+        let refreshed_context = refresh_candidate_readiness(
+            one_of.rewrite_context().clone(),
+            physical_inputs,
+            session_state,
+        )
+        .await;
 
         // Enforce the invariant documented on `CandidateMetadata`: NotReady
         // never reaches the cost function. A provider can transition to
@@ -641,70 +648,63 @@ fn drop_not_ready_after_refresh(
 /// so the cost function sees the definitive readiness rather than the
 /// stale LP-time snapshot.
 ///
-/// Fast path: if every `Materialized` candidate already reports `Ready`
-/// at LP-rewrite time, refresh is a no-op. `Ready` is monotone in the
-/// provider models we ship for (an index that has loaded doesn't
-/// spontaneously unload between LP and physical planning), so no
-/// post-scan call can move a `Ready` back to `Unknown` or `NotReady`.
-/// The only candidates whose value can change under refresh are the
-/// `Unknown` ones — cold lazy indexes that `scan()` may have warmed.
-/// Skipping the refresh in the all-`Ready` case avoids one catalog walk
-/// per query on the warm hot path (the common case once every MV has
-/// been touched at least once).
+/// For each `Materialized` candidate the refresh prefers the atomic
+/// readiness captured at scan time (via `ReadinessAnnotatedExec` in the
+/// candidate's `physical_input`) over racy re-sampling. Providers that
+/// haven't opted into the wrapper fall back to sampling the current
+/// `rewrite_readiness()` through the catalog — this is best-effort and
+/// can be stale under concurrent snapshot swaps (see `ReadinessAnnotatedExec`).
 ///
-/// Providers whose `rewrite_readiness()` is not monotone (e.g. an index
-/// that unloads on memory pressure) should not rely on this fast path;
-/// they can opt out by never reporting `Ready` at LP-rewrite time.
-///
-/// Lookup failures (table not found in the catalog, provider is no
-/// longer a `Materialized`, `cast_to_materialized` error) fall back to
-/// the LP-time value — the goal is to be at least as accurate as the
-/// previous value, never less.
+/// Lookup failures on the fallback path (table not found in the
+/// catalog, provider is no longer a `Materialized`, `cast_to_materialized`
+/// error) preserve the LP-time value — never downgrade what we already
+/// observed.
 async fn refresh_candidate_readiness(
     context: RewriteContext,
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
     session_state: &SessionState,
 ) -> RewriteContext {
-    let any_unknown = context.candidates().iter().any(|c| {
-        matches!(
-            c,
-            CandidateMetadata::Materialized {
-                readiness: RewriteReadiness::Unknown,
-                ..
-            }
-        )
-    });
-    if !any_unknown {
-        return context;
-    }
-
     let catalog_list = session_state.catalog_list();
     let default_catalog = &session_state.config().options().catalog.default_catalog;
     let default_schema = &session_state.config().options().catalog.default_schema;
 
+    let candidates = context.candidates();
+    // Alignment-tolerant zipping: if a caller supplied metadata whose
+    // length differs from `physical_inputs`, we can't safely pair them,
+    // so we skip the annotated lookup for the misaligned indices. The
+    // downstream `drop_not_ready_after_refresh` filter handles the same
+    // case defensively.
+    let aligned = candidates.len() == physical_inputs.len();
+
     let refreshed: Vec<CandidateMetadata> =
-        futures::future::join_all(context.candidates().iter().map(|c| async move {
+        futures::future::join_all(candidates.iter().enumerate().map(|(idx, c)| async move {
             match c {
                 CandidateMetadata::Base => CandidateMetadata::Base,
-                // Ready is monotone — skip the per-candidate catalog walk too.
-                CandidateMetadata::Materialized {
-                    table_ref,
-                    readiness: RewriteReadiness::Ready,
-                } => CandidateMetadata::Materialized {
-                    table_ref: table_ref.clone(),
-                    readiness: RewriteReadiness::Ready,
-                },
                 CandidateMetadata::Materialized {
                     table_ref,
                     readiness,
                 } => {
-                    let new_readiness = resolve_current_readiness(
-                        catalog_list.as_ref(),
-                        default_catalog,
-                        default_schema,
-                        table_ref,
-                    )
-                    .await
-                    .unwrap_or(*readiness);
+                    // Prefer atomically-captured readiness from the physical
+                    // input over sampling — closes the race between the
+                    // snapshot scan read from and the current provider state.
+                    let annotated = if aligned {
+                        readiness_from_plan(&physical_inputs[idx])
+                    } else {
+                        None
+                    };
+
+                    let new_readiness = match annotated {
+                        Some(r) => r,
+                        None => resolve_current_readiness(
+                            catalog_list.as_ref(),
+                            default_catalog,
+                            default_schema,
+                            table_ref,
+                        )
+                        .await
+                        .unwrap_or(*readiness),
+                    };
+
                     CandidateMetadata::Materialized {
                         table_ref: table_ref.clone(),
                         readiness: new_readiness,
@@ -724,13 +724,13 @@ async fn resolve_current_readiness(
     catalog_list: &dyn datafusion::catalog::CatalogProviderList,
     default_catalog: &str,
     default_schema: &str,
-    table_ref: &str,
+    table_ref: &TableReference,
 ) -> Option<RewriteReadiness> {
-    // `table_ref` is the `.to_string()` of a `TableReference`, which for a
-    // `Full` variant renders as "catalog.schema.table". `TableReference::from`
-    // treats any &str as a `Bare` ref, so we need `parse_str` to split dotted
-    // names back into their component parts before catalog resolution.
-    let resolved = TableReference::parse_str(table_ref).resolve(default_catalog, default_schema);
+    // Resolve the (possibly bare or partial) reference against the
+    // session's default catalog/schema without ever going through
+    // `Display`/`parse_str`, which is not lossless for quoted or dotted
+    // identifiers.
+    let resolved = table_ref.clone().resolve(default_catalog, default_schema);
     let catalog = catalog_list.catalog(resolved.catalog.as_ref())?;
     let schema = catalog.schema(resolved.schema.as_ref())?;
     let table = match schema.table(resolved.table.as_ref()).await {
@@ -1044,6 +1044,129 @@ impl PhysicalOptimizerRule for PruneCandidates {
     }
 }
 
+/// Wraps the `ExecutionPlan` returned by a `Materialized` provider's
+/// `scan()` together with the readiness value captured at scan time.
+///
+/// Providers use this to close the race between "which snapshot did
+/// scan read from" and "what does `rewrite_readiness()` return now".
+/// Sampling `rewrite_readiness()` again after `scan()` has returned is
+/// racy — a concurrent snapshot swap can publish new state between the
+/// two calls, letting an `EmptyExec` from the old snapshot be labelled
+/// with readiness from the new one. If the provider computes both
+/// atomically (from the same state Arc, under the same read lock, etc.)
+/// and wraps the returned plan with `ReadinessAnnotatedExec`, the
+/// physical-time refresh in `ViewExploitationPlanner::plan_extension`
+/// reads the annotated value verbatim instead of re-sampling.
+///
+/// The wrapper is transparent: all `ExecutionPlan` methods delegate to
+/// the inner plan, so downstream operators see the same shape as if the
+/// provider returned `inner` directly.
+///
+/// Providers that don't wrap fall back to the pre-existing (racy)
+/// sampling path in the refresh, which remains supported for backward
+/// compatibility.
+#[derive(Debug)]
+pub struct ReadinessAnnotatedExec {
+    inner: Arc<dyn ExecutionPlan>,
+    readiness: RewriteReadiness,
+    properties: Arc<PlanProperties>,
+}
+
+impl ReadinessAnnotatedExec {
+    /// Wrap `inner` with the readiness captured atomically at scan time.
+    pub fn new(inner: Arc<dyn ExecutionPlan>, readiness: RewriteReadiness) -> Self {
+        let properties = Arc::clone(inner.properties());
+        Self {
+            inner,
+            readiness,
+            properties,
+        }
+    }
+
+    /// Readiness captured at the moment the provider produced `inner`.
+    pub fn readiness(&self) -> RewriteReadiness {
+        self.readiness
+    }
+
+    /// The wrapped plan.
+    pub fn inner(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.inner
+    }
+}
+
+impl DisplayAs for ReadinessAnnotatedExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "ReadinessAnnotatedExec: readiness={:?}", self.readiness)
+            }
+            DisplayFormatType::TreeRender => Ok(()),
+        }
+    }
+}
+
+impl ExecutionPlan for ReadinessAnnotatedExec {
+    fn name(&self) -> &str {
+        "ReadinessAnnotatedExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.inner]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Plan(format!(
+                "ReadinessAnnotatedExec expects exactly one child, got {}",
+                children.len()
+            )));
+        }
+        Ok(Arc::new(ReadinessAnnotatedExec::new(
+            children.into_iter().next().unwrap(),
+            self.readiness,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        self.inner.execute(partition, context)
+    }
+
+    fn partition_statistics(
+        &self,
+        partition: Option<usize>,
+    ) -> Result<Arc<datafusion_common::Statistics>> {
+        self.inner.partition_statistics(partition)
+    }
+}
+
+/// Depth-first search for the nearest `ReadinessAnnotatedExec` in a
+/// physical plan tree. Returns its readiness value, or `None` if the
+/// tree doesn't contain one (e.g. the provider hasn't opted in). Used
+/// by the physical-time refresh to prefer atomically-captured readiness
+/// over racy re-sampling.
+pub fn readiness_from_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<RewriteReadiness> {
+    if let Some(annotated) = plan.downcast_ref::<ReadinessAnnotatedExec>() {
+        return Some(annotated.readiness());
+    }
+    for child in plan.children() {
+        if let Some(readiness) = readiness_from_plan(child) {
+            return Some(readiness);
+        }
+    }
+    None
+}
+
 /// Compare two Arrow schemas ignoring field nullability.
 fn schemas_equal_ignoring_nullability(a: &arrow_schema::Schema, b: &arrow_schema::Schema) -> bool {
     a.fields().len() == b.fields().len()
@@ -1192,15 +1315,17 @@ mod tests_rewrite_context {
 
     #[test]
     fn rewrite_context_builder_attaches_candidate_metadata() {
+        let mv_a_ref = TableReference::bare("catalog.schema.mv_a");
+        let mv_b_ref = TableReference::bare("catalog.schema.mv_b");
         let ctx =
             RewriteContext::new(vec!["catalog.schema.root".to_string()]).with_candidates(vec![
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
-                    table_ref: "catalog.schema.mv_a".to_string(),
+                    table_ref: mv_a_ref.clone(),
                     readiness: RewriteReadiness::Ready,
                 },
                 CandidateMetadata::Materialized {
-                    table_ref: "catalog.schema.mv_b".to_string(),
+                    table_ref: mv_b_ref.clone(),
                     readiness: RewriteReadiness::Unknown,
                 },
             ]);
@@ -1208,20 +1333,20 @@ mod tests_rewrite_context {
         let cands = ctx.candidates();
         assert_eq!(cands.len(), 3);
         assert!(matches!(cands[0], CandidateMetadata::Base));
-        assert!(matches!(
+        assert_eq!(
             cands[1],
             CandidateMetadata::Materialized {
-                ref table_ref,
+                table_ref: mv_a_ref,
                 readiness: RewriteReadiness::Ready,
-            } if table_ref == "catalog.schema.mv_a"
-        ));
-        assert!(matches!(
+            }
+        );
+        assert_eq!(
             cands[2],
             CandidateMetadata::Materialized {
-                ref table_ref,
+                table_ref: mv_b_ref,
                 readiness: RewriteReadiness::Unknown,
-            } if table_ref == "catalog.schema.mv_b"
-        ));
+            }
+        );
     }
 
     #[test]
@@ -1248,7 +1373,7 @@ mod tests_rewrite_context {
             RewriteContext::new(vec!["catalog.schema.root".to_string()]).with_candidates(vec![
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
-                    table_ref: "catalog.schema.mv_a".to_string(),
+                    table_ref: TableReference::bare("catalog.schema.mv_a"),
                     readiness: RewriteReadiness::Ready,
                 },
             ]),
@@ -1306,7 +1431,7 @@ mod tests_rewrite_context {
             .expect("candidate plan");
 
         let mv_meta = CandidateMetadata::Materialized {
-            table_ref: "catalog.schema.mv_a".to_string(),
+            table_ref: TableReference::bare("catalog.schema.mv_a"),
             readiness: RewriteReadiness::Ready,
         };
         let one_of = OneOf::with_rewrite_context(
@@ -1390,7 +1515,7 @@ mod tests_rewrite_context {
         let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
             .chain(candidates.into_iter().map(|(_, r, readiness)| {
                 CandidateMetadata::Materialized {
-                    table_ref: r.to_string(),
+                    table_ref: r,
                     readiness,
                 }
             }))
@@ -1401,21 +1526,21 @@ mod tests_rewrite_context {
         assert_eq!(
             metadata[1],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_a".to_string(),
+                table_ref: TableReference::bare("catalog.schema.mv_a"),
                 readiness: RewriteReadiness::Ready,
             }
         );
         assert_eq!(
             metadata[2],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_b".to_string(),
+                table_ref: TableReference::bare("catalog.schema.mv_b"),
                 readiness: RewriteReadiness::Ready,
             }
         );
         assert_eq!(
             metadata[3],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_c".to_string(),
+                table_ref: TableReference::bare("catalog.schema.mv_c"),
                 readiness: RewriteReadiness::Ready,
             }
         );
@@ -1455,7 +1580,7 @@ mod tests_rewrite_context {
         let metadata: Vec<CandidateMetadata> = std::iter::once(CandidateMetadata::Base)
             .chain(candidates.into_iter().map(|(_, r, readiness)| {
                 CandidateMetadata::Materialized {
-                    table_ref: r.to_string(),
+                    table_ref: r,
                     readiness,
                 }
             }))
@@ -1465,21 +1590,21 @@ mod tests_rewrite_context {
         assert_eq!(
             metadata[1],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_a".to_string(),
+                table_ref: TableReference::bare("catalog.schema.mv_a"),
                 readiness: RewriteReadiness::Unknown,
             }
         );
         assert_eq!(
             metadata[2],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_b".to_string(),
+                table_ref: TableReference::bare("catalog.schema.mv_b"),
                 readiness: RewriteReadiness::Ready,
             }
         );
         assert_eq!(
             metadata[3],
             CandidateMetadata::Materialized {
-                table_ref: "catalog.schema.mv_c".to_string(),
+                table_ref: TableReference::bare("catalog.schema.mv_c"),
                 readiness: RewriteReadiness::Unknown,
             }
         );
@@ -1494,11 +1619,11 @@ mod tests_rewrite_context {
         // variant on the same table_ref — reintroducing the exact regression
         // this PR fixes.
         let ready = CandidateMetadata::Materialized {
-            table_ref: "catalog.schema.mv_a".to_string(),
+            table_ref: TableReference::bare("catalog.schema.mv_a"),
             readiness: RewriteReadiness::Ready,
         };
         let unknown = CandidateMetadata::Materialized {
-            table_ref: "catalog.schema.mv_a".to_string(),
+            table_ref: TableReference::bare("catalog.schema.mv_a"),
             readiness: RewriteReadiness::Unknown,
         };
         assert_ne!(ready, unknown);
@@ -1506,7 +1631,7 @@ mod tests_rewrite_context {
         // Same readiness + same table_ref must still compare equal so
         // dedup / cache-key uses still work.
         let ready_again = CandidateMetadata::Materialized {
-            table_ref: "catalog.schema.mv_a".to_string(),
+            table_ref: TableReference::bare("catalog.schema.mv_a"),
             readiness: RewriteReadiness::Ready,
         };
         assert_eq!(ready, ready_again);
@@ -1528,7 +1653,7 @@ mod tests_rewrite_context {
             .expect("candidate plan");
 
         let mv_meta = CandidateMetadata::Materialized {
-            table_ref: "catalog.schema.mv_cold_lazy".to_string(),
+            table_ref: TableReference::bare("catalog.schema.mv_cold_lazy"),
             readiness: RewriteReadiness::Unknown,
         };
         let one_of = OneOf::with_rewrite_context(
@@ -1713,7 +1838,9 @@ mod tests_view_matcher_readiness_filter {
             .candidates()
             .iter()
             .filter_map(|c| match c {
-                CandidateMetadata::Materialized { table_ref, .. } => Some(table_ref.clone()),
+                CandidateMetadata::Materialized { table_ref, .. } => {
+                    Some(table_ref.table().to_string())
+                }
                 CandidateMetadata::Base => None,
             })
             .collect()
@@ -1815,7 +1942,7 @@ mod tests_view_matcher_readiness_filter {
                 CandidateMetadata::Materialized {
                     table_ref,
                     readiness,
-                } if table_ref == "mv_ready" => Some(*readiness),
+                } if table_ref.table() == "mv_ready" => Some(*readiness),
                 _ => None,
             })
             .expect("Ready MV should be a candidate");
@@ -1827,7 +1954,7 @@ mod tests_view_matcher_readiness_filter {
                 CandidateMetadata::Materialized {
                     table_ref,
                     readiness,
-                } if table_ref == "mv_unknown" => Some(*readiness),
+                } if table_ref.table() == "mv_unknown" => Some(*readiness),
                 _ => None,
             })
             .expect("Unknown MV should be a candidate");
@@ -1911,7 +2038,7 @@ mod tests_view_matcher_readiness_filter {
                 CandidateMetadata::Materialized {
                     table_ref,
                     readiness,
-                } if table_ref == "mv_cold_lazy" => Some(*readiness),
+                } if table_ref.table() == "mv_cold_lazy" => Some(*readiness),
                 _ => None,
             })
             .expect("Unknown provider must be admitted as a candidate");
@@ -1933,7 +2060,7 @@ mod tests_view_matcher_readiness_filter {
                 CandidateMetadata::Materialized {
                     table_ref,
                     readiness,
-                } if table_ref == "mv_cold_lazy" => Some(*readiness),
+                } if table_ref.table() == "mv_cold_lazy" => Some(*readiness),
                 _ => None,
             })
             .expect("provider that transitions to Ready must remain a candidate");
@@ -1964,7 +2091,7 @@ mod tests_physical_time_readiness_refresh {
                 CandidateMetadata::Materialized {
                     table_ref,
                     readiness,
-                } if table_ref.ends_with(name) => Some(*readiness),
+                } if table_ref.table() == name => Some(*readiness),
                 _ => None,
             })
             .unwrap_or_else(|| {
@@ -1978,47 +2105,31 @@ mod tests_physical_time_readiness_refresh {
     /// Build a `RewriteContext` shaped like what `f_down` would produce: a
     /// Base branch plus one `Materialized` branch pointing at the
     /// fully-qualified `table_ref`.
-    fn one_mv_context(table_ref: &str, lp_time_readiness: RewriteReadiness) -> RewriteContext {
+    fn one_mv_context(
+        table_ref: TableReference,
+        lp_time_readiness: RewriteReadiness,
+    ) -> RewriteContext {
         RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
             CandidateMetadata::Base,
             CandidateMetadata::Materialized {
-                table_ref: table_ref.to_string(),
+                table_ref,
                 readiness: lp_time_readiness,
             },
         ])
     }
 
-    #[tokio::test]
-    async fn refresh_is_noop_when_every_candidate_already_ready() {
-        // Warm hot path: after every MV has been touched at least once
-        // its LP-time readiness is `Ready` for every subsequent query.
-        // The refresh must skip the catalog walk entirely — no lookup,
-        // no `rewrite_readiness()` call — because `Ready` is monotone
-        // (a loaded index doesn't spontaneously unload). We prove this
-        // by not registering the MVs in the SessionContext at all: if
-        // the refresh tried to resolve their `table_ref` through the
-        // catalog it would trigger the LP-time fallback branch instead
-        // of returning verbatim; the assertion below would still pass
-        // in that case, but the surrounding test — `refresh_falls_back
-        // _to_lp_time_value_when_provider_missing` — already covers the
-        // "resolve then fall back" case, so any observable difference
-        // here would come from the fast path being taken.
-        let ctx = SessionContext::new();
-        let context = RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
-            CandidateMetadata::Base,
-            CandidateMetadata::Materialized {
-                table_ref: "atlas.public.mv_hot_a".to_string(),
-                readiness: RewriteReadiness::Ready,
-            },
-            CandidateMetadata::Materialized {
-                table_ref: "atlas.public.mv_hot_b".to_string(),
-                readiness: RewriteReadiness::Ready,
-            },
-        ]);
-
-        let refreshed = refresh_candidate_readiness(context.clone(), &ctx.state()).await;
-        // Identical shape — fast path returned the same context.
-        assert_eq!(refreshed, context);
+    /// Build the `TableReference` that atlas / the default catalog would
+    /// register a mock provider under, given the caller's simple table name.
+    fn default_qualified_table_ref(
+        state: &datafusion::execution::context::SessionState,
+        table: &str,
+    ) -> TableReference {
+        let opts = &state.config().options().catalog;
+        TableReference::full(
+            opts.default_catalog.clone(),
+            opts.default_schema.clone(),
+            table.to_string(),
+        )
     }
 
     #[tokio::test]
@@ -2034,16 +2145,10 @@ mod tests_physical_time_readiness_refresh {
         ctx.register_table("mv_lazy", Arc::clone(&mv) as Arc<dyn TableProvider>)
             .expect("register mv_lazy");
         let state = ctx.state();
-        // At registration time atlas would key the metadata by the fully
-        // qualified name the catalog uses; do the same here.
-        let fq_name = format!(
-            "{}.{}.mv_lazy",
-            state.config().options().catalog.default_catalog,
-            state.config().options().catalog.default_schema,
-        );
+        let mv_ref = default_qualified_table_ref(&state, "mv_lazy");
 
         // LP-time snapshot: cold.
-        let context = one_mv_context(&fq_name, RewriteReadiness::Unknown);
+        let context = one_mv_context(mv_ref, RewriteReadiness::Unknown);
 
         // Physical planning would have called scan() on the MV branch by
         // now; call it directly to simulate that side effect.
@@ -2053,7 +2158,7 @@ mod tests_physical_time_readiness_refresh {
             .expect("scan flips readiness");
 
         // Now refresh — should observe Ready.
-        let refreshed = refresh_candidate_readiness(context, &state).await;
+        let refreshed = refresh_candidate_readiness(context, &[], &state).await;
         assert_eq!(
             readiness_for(&refreshed, "mv_lazy"),
             RewriteReadiness::Ready
@@ -2067,9 +2172,12 @@ mod tests_physical_time_readiness_refresh {
         // than defaulting to Unknown, so a transient catalog hiccup can't
         // silently downgrade a previously-observed Ready to Unknown.
         let ctx = SessionContext::new();
-        let context = one_mv_context("datafusion.public.does_not_exist", RewriteReadiness::Ready);
+        let context = one_mv_context(
+            TableReference::full("datafusion", "public", "does_not_exist"),
+            RewriteReadiness::Ready,
+        );
 
-        let refreshed = refresh_candidate_readiness(context, &ctx.state()).await;
+        let refreshed = refresh_candidate_readiness(context, &[], &ctx.state()).await;
         assert_eq!(
             readiness_for(&refreshed, "does_not_exist"),
             RewriteReadiness::Ready,
@@ -2085,26 +2193,21 @@ mod tests_physical_time_readiness_refresh {
         // and confirmed there's no data". `drop_not_ready_after_refresh`
         // then removes the candidate before `OneOfExec::try_new` invokes
         // the cost function, preserving the invariant that NotReady never
-        // reaches cost policy. (Ready -> NotReady is deliberately not
-        // supported — see the fast-path doc on refresh_candidate_readiness.)
+        // reaches cost policy.
         register_materialized::<MockMv>();
         let ctx = SessionContext::new();
         let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
         ctx.register_table("mv_regressed", Arc::clone(&mv) as Arc<dyn TableProvider>)
             .expect("register mv_regressed");
         let state = ctx.state();
-        let fq_name = format!(
-            "{}.{}.mv_regressed",
-            state.config().options().catalog.default_catalog,
-            state.config().options().catalog.default_schema,
-        );
+        let mv_ref = default_qualified_table_ref(&state, "mv_regressed");
 
-        let context = one_mv_context(&fq_name, RewriteReadiness::Unknown);
+        let context = one_mv_context(mv_ref, RewriteReadiness::Unknown);
 
         // Simulated scan concluded that the MV is unpopulated.
         mv.set_readiness(RewriteReadiness::NotReady);
 
-        let refreshed = refresh_candidate_readiness(context, &state).await;
+        let refreshed = refresh_candidate_readiness(context, &[], &state).await;
         assert_eq!(
             readiness_for(&refreshed, "mv_regressed"),
             RewriteReadiness::NotReady
@@ -2118,7 +2221,7 @@ mod tests_physical_time_readiness_refresh {
         let context = RewriteContext::new(vec!["target_t".to_string()])
             .with_candidates(vec![CandidateMetadata::Base]);
 
-        let refreshed = refresh_candidate_readiness(context, &ctx.state()).await;
+        let refreshed = refresh_candidate_readiness(context, &[], &ctx.state()).await;
         assert_eq!(refreshed.candidates().len(), 1);
         assert!(matches!(refreshed.candidates()[0], CandidateMetadata::Base));
     }
@@ -2133,15 +2236,15 @@ mod tests_physical_time_readiness_refresh {
         let candidates = vec![
             CandidateMetadata::Base,
             CandidateMetadata::Materialized {
-                table_ref: "a".to_string(),
+                table_ref: TableReference::bare("a"),
                 readiness: RewriteReadiness::Ready,
             },
             CandidateMetadata::Materialized {
-                table_ref: "b".to_string(),
+                table_ref: TableReference::bare("b"),
                 readiness: RewriteReadiness::NotReady,
             },
             CandidateMetadata::Materialized {
-                table_ref: "c".to_string(),
+                table_ref: TableReference::bare("c"),
                 readiness: RewriteReadiness::Unknown,
             },
         ];
@@ -2154,12 +2257,12 @@ mod tests_physical_time_readiness_refresh {
         assert!(matches!(
             &kept_candidates[1],
             CandidateMetadata::Materialized { table_ref, readiness: RewriteReadiness::Ready }
-                if table_ref == "a"
+                if table_ref.table() == "a"
         ));
         assert!(matches!(
             &kept_candidates[2],
             CandidateMetadata::Materialized { table_ref, readiness: RewriteReadiness::Unknown }
-                if table_ref == "c"
+                if table_ref.table() == "c"
         ));
     }
 
@@ -2199,7 +2302,7 @@ mod tests_physical_time_readiness_refresh {
         let candidates = vec![
             CandidateMetadata::Base,
             CandidateMetadata::Materialized {
-                table_ref: "a".to_string(),
+                table_ref: TableReference::bare("a"),
                 readiness: RewriteReadiness::Ready,
             },
         ];
@@ -2230,11 +2333,11 @@ mod tests_physical_time_readiness_refresh {
         let candidates = vec![
             CandidateMetadata::Base,
             CandidateMetadata::Materialized {
-                table_ref: "a".to_string(),
+                table_ref: TableReference::bare("a"),
                 readiness: RewriteReadiness::NotReady,
             },
             CandidateMetadata::Materialized {
-                table_ref: "b".to_string(),
+                table_ref: TableReference::bare("b"),
                 readiness: RewriteReadiness::NotReady,
             },
         ];
@@ -2297,11 +2400,7 @@ mod tests_physical_time_readiness_refresh {
             .await
             .expect("scan flips readiness");
 
-        let fq_name = format!(
-            "{}.{}.mv_lazy",
-            state.config().options().catalog.default_catalog,
-            state.config().options().catalog.default_schema,
-        );
+        let mv_ref = default_qualified_table_ref(&state, "mv_lazy");
         let base_lp = LogicalPlanBuilder::empty(false).build().expect("base lp");
         let mv_lp = LogicalPlanBuilder::empty(false).build().expect("mv lp");
         let one_of_node = OneOf::with_rewrite_context(
@@ -2309,7 +2408,7 @@ mod tests_physical_time_readiness_refresh {
             RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
-                    table_ref: fq_name.clone(),
+                    table_ref: mv_ref.clone(),
                     readiness: RewriteReadiness::Unknown,
                 },
             ]),
@@ -2350,7 +2449,7 @@ mod tests_physical_time_readiness_refresh {
                 _ => None,
             })
             .expect("expected Materialized entry");
-        assert_eq!(fetched_ref, fq_name);
+        assert_eq!(fetched_ref, mv_ref);
         assert_eq!(
             fetched_readiness,
             RewriteReadiness::Ready,
@@ -2377,11 +2476,7 @@ mod tests_physical_time_readiness_refresh {
         // Simulate scan discovering the MV is unusable.
         mv.set_readiness(RewriteReadiness::NotReady);
 
-        let fq_name = format!(
-            "{}.{}.mv_regressed",
-            state.config().options().catalog.default_catalog,
-            state.config().options().catalog.default_schema,
-        );
+        let mv_ref = default_qualified_table_ref(&state, "mv_regressed");
         let base_lp = LogicalPlanBuilder::empty(false).build().expect("base lp");
         let mv_lp = LogicalPlanBuilder::empty(false).build().expect("mv lp");
         let one_of_node = OneOf::with_rewrite_context(
@@ -2389,7 +2484,7 @@ mod tests_physical_time_readiness_refresh {
             RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
                 CandidateMetadata::Base,
                 CandidateMetadata::Materialized {
-                    table_ref: fq_name,
+                    table_ref: mv_ref,
                     readiness: RewriteReadiness::Unknown,
                 },
             ]),
@@ -2438,23 +2533,128 @@ mod tests_physical_time_readiness_refresh {
         ctx.register_table("mv_b", Arc::clone(&mv_b) as Arc<dyn TableProvider>)
             .expect("register mv_b");
         let state = ctx.state();
-        let default_catalog = &state.config().options().catalog.default_catalog;
-        let default_schema = &state.config().options().catalog.default_schema;
+        let mv_a_ref = default_qualified_table_ref(&state, "mv_a");
+        let mv_b_ref = default_qualified_table_ref(&state, "mv_b");
 
         let context = RewriteContext::new(vec!["target_t".to_string()]).with_candidates(vec![
             CandidateMetadata::Base,
             CandidateMetadata::Materialized {
-                table_ref: format!("{default_catalog}.{default_schema}.mv_a"),
+                table_ref: mv_a_ref,
                 readiness: RewriteReadiness::Ready,
             },
             CandidateMetadata::Materialized {
-                table_ref: format!("{default_catalog}.{default_schema}.mv_b"),
+                table_ref: mv_b_ref,
                 readiness: RewriteReadiness::Unknown,
             },
         ]);
 
-        let refreshed = refresh_candidate_readiness(context, &state).await;
+        let refreshed = refresh_candidate_readiness(context, &[], &state).await;
         assert!(matches!(refreshed.candidates()[0], CandidateMetadata::Base));
         assert_eq!(refreshed.candidates().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn refresh_prefers_annotated_readiness_over_catalog_sampling() {
+        // A provider that wraps its scan output in `ReadinessAnnotatedExec`
+        // captures readiness atomically at scan time. Refresh must read
+        // that captured value verbatim and NOT re-sample the provider —
+        // sampling is racy against concurrent snapshot swaps.
+        //
+        // Set up the scenario where the two values disagree:
+        //   * physical_input carries an annotated `Ready` (what scan saw)
+        //   * the live provider now reports `Unknown` (as if a concurrent
+        //     swap happened after scan returned)
+        // The annotated value must win.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
+        ctx.register_table("mv_annotated", Arc::clone(&mv) as Arc<dyn TableProvider>)
+            .expect("register mv_annotated");
+        let state = ctx.state();
+        let mv_ref = default_qualified_table_ref(&state, "mv_annotated");
+
+        let context = one_mv_context(mv_ref, RewriteReadiness::Unknown);
+        let schema = Arc::new(Schema::empty());
+        let base_input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::clone(&schema)));
+        let inner: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let annotated_input: Arc<dyn ExecutionPlan> =
+            Arc::new(ReadinessAnnotatedExec::new(inner, RewriteReadiness::Ready));
+
+        // Provider says Unknown, annotated input says Ready — annotated wins.
+        let refreshed =
+            refresh_candidate_readiness(context, &[base_input, annotated_input], &state).await;
+        assert_eq!(
+            readiness_for(&refreshed, "mv_annotated"),
+            RewriteReadiness::Ready,
+            "annotated readiness must override sampled value"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_falls_back_to_sampling_when_input_not_annotated() {
+        // Backward-compat: providers that haven't opted into
+        // `ReadinessAnnotatedExec` still get the old sampling behaviour.
+        // Here the provider is unwrapped and the scan (mock) promotes
+        // readiness from Unknown to Ready — refresh must observe it via
+        // catalog sampling.
+        register_materialized::<MockMv>();
+        let ctx = SessionContext::new();
+        let mv = MockMv::new("target_t", RewriteReadiness::Unknown);
+        ctx.register_table("mv_unwrapped", Arc::clone(&mv) as Arc<dyn TableProvider>)
+            .expect("register mv_unwrapped");
+        let state = ctx.state();
+        let mv_ref = default_qualified_table_ref(&state, "mv_unwrapped");
+
+        let context = one_mv_context(mv_ref, RewriteReadiness::Unknown);
+        // Simulated warmup — provider now reports Ready.
+        mv.set_readiness(RewriteReadiness::Ready);
+
+        // Plain (unwrapped) physical_input from the "provider" side.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let base_input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::clone(&schema)));
+        let mv_input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+
+        let refreshed = refresh_candidate_readiness(context, &[base_input, mv_input], &state).await;
+        assert_eq!(
+            readiness_for(&refreshed, "mv_unwrapped"),
+            RewriteReadiness::Ready,
+            "sampling fallback must find the warmed provider"
+        );
+    }
+
+    #[test]
+    fn readiness_from_plan_walks_nested_children() {
+        // `ReadinessAnnotatedExec` doesn't have to be at the top of the
+        // physical tree — DataFusion may wrap the scan's output in
+        // e.g. a `RepartitionExec` before it reaches `plan_extension`.
+        // The walker must reach an annotation nested any depth down.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        use datafusion::physical_plan::repartition::RepartitionExec;
+        use datafusion_physical_expr::Partitioning;
+        let schema = Arc::new(Schema::empty());
+        let leaf: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let annotated: Arc<dyn ExecutionPlan> =
+            Arc::new(ReadinessAnnotatedExec::new(leaf, RewriteReadiness::Ready));
+        let wrapped: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(annotated, Partitioning::RoundRobinBatch(1))
+                .expect("repartition"),
+        );
+
+        let found = readiness_from_plan(&wrapped);
+        assert_eq!(found, Some(RewriteReadiness::Ready));
+    }
+
+    #[test]
+    fn readiness_from_plan_returns_none_when_no_annotation() {
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        assert_eq!(readiness_from_plan(&plan), None);
     }
 }

--- a/src/rewrite/exploitation.rs
+++ b/src/rewrite/exploitation.rs
@@ -601,7 +601,7 @@ impl ExtensionPlanner for ViewExploitationPlanner {
 /// metadata, or a caller that supplied a mismatched vector), the inputs
 /// are passed through unchanged and the metadata is dropped entirely —
 /// preserving a misaligned slice would let it flow into `OneOfExec` and
-/// mis-attribute readiness to the wrong branch inside the cost function.
+/// attribute readiness to the wrong branch inside the cost function.
 /// Callsites without metadata keep their original behaviour (the empty
 /// slice is what the pre-readiness code path also carried).
 fn drop_not_ready_after_refresh(
@@ -2136,7 +2136,11 @@ mod tests_physical_time_readiness_refresh {
 
         let (kept_inputs, kept_candidates) =
             drop_not_ready_after_refresh(&physical_inputs, &candidates);
-        assert_eq!(kept_inputs.len(), 3, "physical inputs must survive so OneOfExec still builds");
+        assert_eq!(
+            kept_inputs.len(),
+            3,
+            "physical inputs must survive so OneOfExec still builds"
+        );
         assert!(
             kept_candidates.is_empty(),
             "misaligned metadata must not be propagated to downstream cost functions"

--- a/src/rewrite/readiness.rs
+++ b/src/rewrite/readiness.rs
@@ -1,0 +1,317 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Readiness-related types and helpers used by the query-rewrite optimizer.
+//!
+//! Two-stage readiness contract:
+//!
+//! 1. At LP-rewrite time, `ViewMatcher` consults
+//!    [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness)
+//!    and drops candidates whose readiness is [`RewriteReadiness::NotReady`].
+//!    `Ready` and `Unknown` both enter the candidate set and their raw
+//!    readiness is recorded on [`CandidateMetadata::Materialized::readiness`].
+//! 2. At physical-planning time (once `TableProvider::scan()` has run on every
+//!    branch), `ViewExploitationPlanner` refreshes the readiness on each
+//!    candidate. Providers that opt into [`ReadinessAnnotatedExec`] have
+//!    their readiness read straight off the plan tree (atomically captured
+//!    at scan time); others fall back to sampling the current provider
+//!    state, which is best-effort but racy under concurrent snapshot swaps.
+//!
+//! The cost function only ever sees `Base` or `Materialized { Ready | Unknown }`
+//! entries — `NotReady` is filtered by both gates before it can reach cost
+//! policy.
+
+use std::sync::Arc;
+
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
+};
+use datafusion_common::{DataFusionError, Result, TableReference};
+
+/// Whether a materialized view is currently safe to route queries to. Reported
+/// by [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness)
+/// and consulted by
+/// [`ViewMatcher`](crate::rewrite::exploitation::ViewMatcher) during LP rewrite
+/// so that unpopulated / in-flight MVs are excluded from the candidate set
+/// upstream of the cost function.
+///
+/// Keeping this a lifecycle abstraction (rather than a proxy such as file
+/// count) means the trait doesn't couple to any specific storage layout —
+/// providers describe their own readiness however they want (index loaded,
+/// snapshot published, migration complete, staleness threshold satisfied,
+/// etc.) and only report the answer.
+// `PartialOrd, Ord` are derived so `CandidateMetadata` (which stores a
+// `RewriteReadiness`) can keep its own `PartialOrd, Ord` derives. The
+// variant ordering has no lifecycle meaning — callers must not depend on
+// `Ready < NotReady < Unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RewriteReadiness {
+    /// The MV is populated and can safely answer the query. The
+    /// `ViewMatchingRewriter` will include it as a rewrite candidate.
+    Ready,
+    /// The MV should not be used yet (index not loaded, ingest task never
+    /// ran after a version bump, snapshot rebuild in progress, etc.).
+    /// The `ViewMatchingRewriter` will drop the MV from the candidate set
+    /// so a query never gets routed to it and silently returns empty.
+    NotReady,
+    /// The provider cannot cheaply determine readiness. The
+    /// `ViewMatchingRewriter` treats this as "include as candidate" and
+    /// propagates the `Unknown` value to the cost function via
+    /// `CandidateMetadata::Materialized { readiness, .. }`, so the caller
+    /// can pick whatever policy fits — e.g. fall back to the base scan
+    /// cost rather than trust an EmptyExec candidate as predicate-pruned.
+    /// Default value returned by the trait's blanket impl so
+    /// backward-compatible providers keep the pre-existing "always a
+    /// candidate" behaviour.
+    Unknown,
+}
+
+/// Per-branch metadata inside a `OneOf` / `OneOfExec`. One variant per branch,
+/// aligned by index with the containing `branches` / `candidates` vector.
+///
+/// Lifecycle judgement (populated / unpopulated / stale / ...) is made in two
+/// stages via [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness):
+///
+/// 1. At LP-rewrite time,
+///    [`ViewMatcher`](crate::rewrite::exploitation::ViewMatcher) drops `NotReady`
+///    providers and admits `Ready` + `Unknown` as candidates.
+/// 2. At physical-planning time, once DataFusion has invoked each provider's
+///    `scan()` (giving lazy indexes a chance to warm),
+///    [`ViewExploitationPlanner`](crate::rewrite::exploitation::ViewExploitationPlanner)
+///    re-consults `rewrite_readiness()` and updates the metadata to the current
+///    value; providers that transitioned to `NotReady` between the two stages are
+///    dropped here.
+///
+/// So any `Materialized` variant that reaches the cost function reflects the
+/// **post-scan** readiness, and `NotReady` is guaranteed to have been filtered
+/// (upstream or downstream of scan) before the cost function runs. `Ready`
+/// and `Unknown` remain distinguishable so cost policy for the two can diverge
+/// (typically: trust `Ready` as safe to route, and fall back to a conservative
+/// estimate for `Unknown`).
+///
+/// The invariant enforced at construction inside
+/// [`ViewMatcher`](crate::rewrite::exploitation::ViewMatcher):
+///
+/// * Index 0 is always [`CandidateMetadata::Base`] — the query's original LP,
+///   with no MV rewrite applied. `OneOf::schema()` reads `branches[0].schema()`
+///   and therefore always exposes the query's schema (not an MV's).
+/// * Indices 1..N are [`CandidateMetadata::Materialized`] entries, sorted
+///   deterministically by `table_ref`. Sorting on the MV's registered
+///   `TableReference` (rather than on the branch LP) keeps the order stable
+///   under downstream LP transformations that happen between LP rewrite and
+///   physical planning — identity projection elimination, always-true filter
+///   folding, etc. change the LP but never the MV's registered name, so the
+///   alignment between this metadata and the physical candidate the cost
+///   function receives survives every optimizer pass.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash)]
+pub enum CandidateMetadata {
+    /// The query's original branch (index 0 in every OneOf).
+    Base,
+    /// A materialized-view rewrite of the query. Only MVs that reported
+    /// `Ready` or `Unknown` readiness reach this state; `NotReady` MVs
+    /// are filtered upstream by
+    /// [`ViewMatcher`](crate::rewrite::exploitation::ViewMatcher).
+    /// Cost functions consult the `readiness` field to distinguish the
+    /// two cases: `Unknown` (the trait default returned by
+    /// [`RewriteReadiness`]) must not be silently treated as `Ready`,
+    /// since that would regress providers that haven't declared a
+    /// lifecycle.
+    Materialized {
+        /// Registered `TableReference` of the source MV. Stored directly
+        /// rather than as `.to_string()` so identifiers with dots or
+        /// quoting round-trip losslessly through the physical-time
+        /// catalog resolution. Stable across LP transformations; safe to
+        /// use as a sort key.
+        table_ref: TableReference,
+        /// Provider readiness as observed at physical-planning time — i.e.
+        /// after DataFusion has invoked `TableProvider::scan()` on this
+        /// branch. Set once at LP rewrite from the provider's initial
+        /// report and refreshed from the same provider inside
+        /// [`ViewExploitationPlanner::plan_extension`](crate::rewrite::exploitation::ViewExploitationPlanner)
+        /// so lazy-index providers surface their warmed-up value.
+        /// Downstream cost functions branch on this to implement their
+        /// `Unknown` policy (e.g. fall back to the base scan cost rather
+        /// than trust an EmptyExec as predicate-pruned).
+        readiness: RewriteReadiness,
+    },
+}
+
+/// Wraps the `ExecutionPlan` returned by a `Materialized` provider's
+/// `scan()` together with the readiness value captured at scan time.
+///
+/// Providers use this to close the race between "which snapshot did
+/// scan read from" and "what does `rewrite_readiness()` return now".
+/// Sampling `rewrite_readiness()` again after `scan()` has returned is
+/// racy — a concurrent snapshot swap can publish new state between the
+/// two calls, letting an `EmptyExec` from the old snapshot be labelled
+/// with readiness from the new one. If the provider computes both
+/// atomically (from the same state Arc, under the same read lock, etc.)
+/// and wraps the returned plan with `ReadinessAnnotatedExec`, the
+/// physical-time refresh in
+/// [`ViewExploitationPlanner::plan_extension`](crate::rewrite::exploitation::ViewExploitationPlanner)
+/// reads the annotated value verbatim instead of re-sampling.
+///
+/// The wrapper is transparent: all `ExecutionPlan` methods delegate to
+/// the inner plan, so downstream operators see the same shape as if the
+/// provider returned `inner` directly.
+///
+/// Providers that don't wrap fall back to the pre-existing (racy)
+/// sampling path in the refresh, which remains supported for backward
+/// compatibility.
+#[derive(Debug)]
+pub struct ReadinessAnnotatedExec {
+    inner: Arc<dyn ExecutionPlan>,
+    readiness: RewriteReadiness,
+    properties: Arc<PlanProperties>,
+}
+
+impl ReadinessAnnotatedExec {
+    /// Wrap `inner` with the readiness captured atomically at scan time.
+    pub fn new(inner: Arc<dyn ExecutionPlan>, readiness: RewriteReadiness) -> Self {
+        let properties = Arc::clone(inner.properties());
+        Self {
+            inner,
+            readiness,
+            properties,
+        }
+    }
+
+    /// Readiness captured at the moment the provider produced `inner`.
+    pub fn readiness(&self) -> RewriteReadiness {
+        self.readiness
+    }
+
+    /// The wrapped plan.
+    pub fn inner(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.inner
+    }
+}
+
+impl DisplayAs for ReadinessAnnotatedExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "ReadinessAnnotatedExec: readiness={:?}", self.readiness)
+            }
+            DisplayFormatType::TreeRender => Ok(()),
+        }
+    }
+}
+
+impl ExecutionPlan for ReadinessAnnotatedExec {
+    fn name(&self) -> &str {
+        "ReadinessAnnotatedExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.inner]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Plan(format!(
+                "ReadinessAnnotatedExec expects exactly one child, got {}",
+                children.len()
+            )));
+        }
+        Ok(Arc::new(ReadinessAnnotatedExec::new(
+            children.into_iter().next().unwrap(),
+            self.readiness,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        self.inner.execute(partition, context)
+    }
+
+    fn partition_statistics(
+        &self,
+        partition: Option<usize>,
+    ) -> Result<Arc<datafusion_common::Statistics>> {
+        self.inner.partition_statistics(partition)
+    }
+}
+
+/// Depth-first search for the nearest `ReadinessAnnotatedExec` in a
+/// physical plan tree. Returns its readiness value, or `None` if the
+/// tree doesn't contain one (e.g. the provider hasn't opted in). Used
+/// by the physical-time refresh to prefer atomically-captured readiness
+/// over racy re-sampling.
+pub fn readiness_from_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<RewriteReadiness> {
+    if let Some(annotated) = plan.downcast_ref::<ReadinessAnnotatedExec>() {
+        return Some(annotated.readiness());
+    }
+    for child in plan.children() {
+        if let Some(readiness) = readiness_from_plan(child) {
+            return Some(readiness);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn readiness_variants_are_distinct_and_comparable() {
+        assert_ne!(RewriteReadiness::Ready, RewriteReadiness::NotReady);
+        assert_ne!(RewriteReadiness::Ready, RewriteReadiness::Unknown);
+        assert_ne!(RewriteReadiness::NotReady, RewriteReadiness::Unknown);
+        assert_eq!(RewriteReadiness::Ready, RewriteReadiness::Ready);
+    }
+
+    #[test]
+    fn readiness_is_copy_and_hashable() {
+        // Ensure the variants can be stored / matched cheaply from the
+        // rewrite path without cloning.
+        fn requires_copy<T: Copy>() {}
+        fn requires_hash<T: std::hash::Hash>() {}
+        requires_copy::<RewriteReadiness>();
+        requires_hash::<RewriteReadiness>();
+    }
+
+    #[test]
+    fn readiness_annotated_exec_delegates_properties_and_children() {
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let inner: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::clone(&schema)));
+        let inner_props = Arc::clone(inner.properties());
+        let annotated = ReadinessAnnotatedExec::new(Arc::clone(&inner), RewriteReadiness::Ready);
+
+        assert_eq!(annotated.readiness(), RewriteReadiness::Ready);
+        // Same schema/partitioning as inner — the wrapper is transparent.
+        assert!(Arc::ptr_eq(annotated.properties(), &inner_props));
+        // Inner exposed as the sole child.
+        let children = annotated.children();
+        assert_eq!(children.len(), 1);
+        assert!(Arc::ptr_eq(children[0], &inner));
+    }
+}

--- a/src/rewrite/readiness.rs
+++ b/src/rewrite/readiness.rs
@@ -43,6 +43,7 @@ use datafusion::execution::TaskContext;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
+use datafusion_common::tree_node::{Transformed, TreeNode};
 use datafusion_common::{DataFusionError, Result, TableReference};
 
 use crate::materialized::cast_to_materialized;
@@ -281,6 +282,29 @@ pub fn readiness_from_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<RewriteReadi
     None
 }
 
+/// Remove every `ReadinessAnnotatedExec` from a physical plan tree and
+/// return the plan with each wrapper collapsed to its inner. Used by
+/// `ViewExploitationPlanner::plan_extension` after `readiness_from_plan`
+/// has extracted the annotation — the wrapper's job is done at that
+/// point and it shouldn't leak into the plan handed to downstream
+/// optimizers, cost functions, `OneOfExec`, or physical-plan codecs.
+///
+/// The wrapper is deliberately minimal (it only delegates `properties`,
+/// `execute`, and `partition_statistics`); leaving it in place would
+/// silently block optimizer passes such as limit pushdown, projection
+/// pushdown, or `with_preserve_order`, which look at
+/// `ExecutionPlan` trait methods we don't proxy.
+pub fn strip_readiness_annotation(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    plan.transform(&|node: Arc<dyn ExecutionPlan>| {
+        if let Some(annotated) = node.downcast_ref::<ReadinessAnnotatedExec>() {
+            Ok(Transformed::yes(Arc::clone(annotated.inner())))
+        } else {
+            Ok(Transformed::no(node))
+        }
+    })
+    .map(|t| t.data)
+}
+
 /// Pair-wise filter that drops every `Materialized` candidate whose
 /// refreshed readiness is `NotReady`, along with its aligned entry in
 /// `physical_inputs`. Base is never filtered.
@@ -476,5 +500,62 @@ mod tests {
         let children = annotated.children();
         assert_eq!(children.len(), 1);
         assert!(Arc::ptr_eq(children[0], &inner));
+    }
+
+    #[test]
+    fn strip_returns_inner_for_bare_annotated_exec() {
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let inner: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let annotated: Arc<dyn ExecutionPlan> = Arc::new(ReadinessAnnotatedExec::new(
+            Arc::clone(&inner),
+            RewriteReadiness::Ready,
+        ));
+
+        let stripped = strip_readiness_annotation(annotated).expect("strip");
+        assert!(
+            stripped.downcast_ref::<ReadinessAnnotatedExec>().is_none(),
+            "top-level wrapper must be gone after strip"
+        );
+        assert!(Arc::ptr_eq(&stripped, &inner));
+    }
+
+    #[test]
+    fn strip_replaces_annotated_exec_inside_nested_plan() {
+        // Providers wrap their scan output, but DataFusion may put a
+        // Filter/Projection/Repartition on top before `plan_extension` sees
+        // the plan. Strip must find the wrapper wherever it sits.
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        use datafusion::physical_plan::repartition::RepartitionExec;
+        use datafusion_physical_expr::Partitioning;
+        let schema = Arc::new(Schema::empty());
+        let leaf: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let annotated: Arc<dyn ExecutionPlan> = Arc::new(ReadinessAnnotatedExec::new(
+            Arc::clone(&leaf),
+            RewriteReadiness::Ready,
+        ));
+        let wrapped: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(annotated, Partitioning::RoundRobinBatch(1))
+                .expect("repartition"),
+        );
+
+        let stripped = strip_readiness_annotation(wrapped).expect("strip");
+        assert!(
+            readiness_from_plan(&stripped).is_none(),
+            "no ReadinessAnnotatedExec should remain anywhere in the tree"
+        );
+    }
+
+    #[test]
+    fn strip_is_noop_when_no_annotation_present() {
+        use arrow_schema::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::empty());
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+
+        let stripped = strip_readiness_annotation(Arc::clone(&plan)).expect("strip");
+        assert!(Arc::ptr_eq(&stripped, &plan));
     }
 }

--- a/src/rewrite/readiness.rs
+++ b/src/rewrite/readiness.rs
@@ -37,11 +37,17 @@
 
 use std::sync::Arc;
 
+use datafusion::catalog::CatalogProviderList;
+use datafusion::execution::context::SessionState;
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
 use datafusion_common::{DataFusionError, Result, TableReference};
+
+use crate::materialized::cast_to_materialized;
+
+use super::exploitation::RewriteContext;
 
 /// Whether a materialized view is currently safe to route queries to. Reported
 /// by [`Materialized::rewrite_readiness`](crate::materialized::Materialized::rewrite_readiness)
@@ -273,6 +279,163 @@ pub fn readiness_from_plan(plan: &Arc<dyn ExecutionPlan>) -> Option<RewriteReadi
         }
     }
     None
+}
+
+/// Pair-wise filter that drops every `Materialized` candidate whose
+/// refreshed readiness is `NotReady`, along with its aligned entry in
+/// `physical_inputs`. Base is never filtered.
+///
+/// If `candidates` is empty or is not aligned with `physical_inputs`
+/// (older callsites that constructed the `OneOf` without per-branch
+/// metadata, or a caller that supplied a mismatched vector), the inputs
+/// are passed through unchanged and the metadata is dropped entirely —
+/// preserving a misaligned slice would let it flow into `OneOfExec` and
+/// attribute readiness to the wrong branch inside the cost function.
+/// Callsites without metadata keep their original behaviour (the empty
+/// slice is what the pre-readiness code path also carried).
+pub(super) fn drop_not_ready_after_refresh(
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
+    candidates: &[CandidateMetadata],
+) -> (Vec<Arc<dyn ExecutionPlan>>, Vec<CandidateMetadata>) {
+    if candidates.len() != physical_inputs.len() {
+        return (physical_inputs.to_vec(), Vec::new());
+    }
+    let mut kept_inputs = Vec::with_capacity(physical_inputs.len());
+    let mut kept_candidates = Vec::with_capacity(candidates.len());
+    for (input, cand) in physical_inputs.iter().zip(candidates.iter()) {
+        let drop = matches!(
+            cand,
+            CandidateMetadata::Materialized {
+                readiness: RewriteReadiness::NotReady,
+                ..
+            }
+        );
+        if drop {
+            continue;
+        }
+        kept_inputs.push(Arc::clone(input));
+        kept_candidates.push(cand.clone());
+    }
+    (kept_inputs, kept_candidates)
+}
+
+/// Re-consult every `Materialized` candidate's `rewrite_readiness()` and
+/// return a `RewriteContext` whose metadata reflects the current values.
+///
+/// Called from `ViewExploitationPlanner::plan_extension` once
+/// physical inputs have been planned (i.e. after `TableProvider::scan()`
+/// has run on every candidate branch). Providers whose readiness only
+/// becomes definite after scan initialization (lazy indexes, warmup jobs,
+/// snapshot swaps that happen inside `scan`) surface their new value here
+/// so the cost function sees the definitive readiness rather than the
+/// stale LP-time snapshot.
+///
+/// For each `Materialized` candidate the refresh prefers the atomic
+/// readiness captured at scan time (via `ReadinessAnnotatedExec` in the
+/// candidate's `physical_input`) over racy re-sampling. Providers that
+/// haven't opted into the wrapper fall back to sampling the current
+/// `rewrite_readiness()` through the catalog — this is best-effort and
+/// can be stale under concurrent snapshot swaps (see `ReadinessAnnotatedExec`).
+///
+/// Lookup failures on the fallback path (table not found in the
+/// catalog, provider is no longer a `Materialized`, `cast_to_materialized`
+/// error) preserve the LP-time value — never downgrade what we already
+/// observed.
+pub(super) async fn refresh_candidate_readiness(
+    context: RewriteContext,
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
+    session_state: &SessionState,
+) -> RewriteContext {
+    let catalog_list = session_state.catalog_list();
+    let default_catalog = &session_state.config().options().catalog.default_catalog;
+    let default_schema = &session_state.config().options().catalog.default_schema;
+
+    let candidates = context.candidates();
+    // Alignment-tolerant zipping: if a caller supplied metadata whose
+    // length differs from `physical_inputs`, we can't safely pair them,
+    // so we skip the annotated lookup for the misaligned indices. The
+    // downstream `drop_not_ready_after_refresh` filter handles the same
+    // case defensively.
+    let aligned = candidates.len() == physical_inputs.len();
+
+    let refreshed: Vec<CandidateMetadata> =
+        futures::future::join_all(candidates.iter().enumerate().map(|(idx, c)| async move {
+            match c {
+                CandidateMetadata::Base => CandidateMetadata::Base,
+                CandidateMetadata::Materialized {
+                    table_ref,
+                    readiness,
+                } => {
+                    // Prefer atomically-captured readiness from the physical
+                    // input over sampling — closes the race between the
+                    // snapshot scan read from and the current provider state.
+                    let annotated = if aligned {
+                        readiness_from_plan(&physical_inputs[idx])
+                    } else {
+                        None
+                    };
+
+                    let new_readiness = match annotated {
+                        Some(r) => r,
+                        None => resolve_current_readiness(
+                            catalog_list.as_ref(),
+                            default_catalog,
+                            default_schema,
+                            table_ref,
+                        )
+                        .await
+                        .unwrap_or(*readiness),
+                    };
+
+                    CandidateMetadata::Materialized {
+                        table_ref: table_ref.clone(),
+                        readiness: new_readiness,
+                    }
+                }
+            }
+        }))
+        .await;
+
+    context.with_candidates(refreshed)
+}
+
+/// Resolve `table_ref` through the catalog list and re-consult the
+/// provider's `rewrite_readiness()`. Returns `None` on any lookup failure
+/// so the caller can fall back to the LP-time value.
+async fn resolve_current_readiness(
+    catalog_list: &dyn CatalogProviderList,
+    default_catalog: &str,
+    default_schema: &str,
+    table_ref: &TableReference,
+) -> Option<RewriteReadiness> {
+    // Resolve the (possibly bare or partial) reference against the
+    // session's default catalog/schema without ever going through
+    // `Display`/`parse_str`, which is not lossless for quoted or dotted
+    // identifiers.
+    let resolved = table_ref.clone().resolve(default_catalog, default_schema);
+    let catalog = catalog_list.catalog(resolved.catalog.as_ref())?;
+    let schema = catalog.schema(resolved.schema.as_ref())?;
+    let table = match schema.table(resolved.table.as_ref()).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            log::trace!("refresh_candidate_readiness: no table {table_ref} in catalog");
+            return None;
+        }
+        Err(e) => {
+            log::warn!("refresh_candidate_readiness: catalog lookup failed for {table_ref}: {e}");
+            return None;
+        }
+    };
+    match cast_to_materialized(table.as_ref()) {
+        Ok(Some(mv)) => Some(mv.rewrite_readiness()),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!(
+                "refresh_candidate_readiness: cast_to_materialized failed for {table_ref}: {e}"
+            );
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/rewrite/readiness.rs
+++ b/src/rewrite/readiness.rs
@@ -61,9 +61,9 @@ use super::exploitation::RewriteContext;
 /// providers describe their own readiness however they want (index loaded,
 /// snapshot published, migration complete, staleness threshold satisfied,
 /// etc.) and only report the answer.
-// `PartialOrd, Ord` are derived so `CandidateMetadata` (which stores a
-// `RewriteReadiness`) can keep its own `PartialOrd, Ord` derives. The
-// variant ordering has no lifecycle meaning — callers must not depend on
+// `PartialOrd`/`Ord` are derived so types that embed `RewriteReadiness` (e.g.
+// candidate metadata) can derive ordering traits when needed. The variant
+// ordering has no lifecycle meaning — callers must not depend on
 // `Ready < NotReady < Unknown`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RewriteReadiness {


### PR DESCRIPTION
## Summary

Empty candidate plans currently look indistinguishable to a cost function regardless of source. A fully-populated MV whose leading-sort-key stats prove absence of a rare literal via metadata alone (X-3269 case, e.g. `WHERE composite_ticker = 'PQXX'` on `constituents_by_composite_ticker_v4`) collapses to bare `EmptyExec` — same shape as a freshly-deployed MV whose ingest task hasn't run yet. Downstream discriminators can't tell them apart and end up either penalising both (X-3269: specialised MV loses to a 30s base-table scan) or trusting both (X-2174: unpopulated MVs silently return empty answers).

This PR fixes the semantics by splitting the two concerns across three layers:

1. **LP-time filter in `ViewMatcher::f_down`** via a new
   `Materialized::rewrite_readiness() -> RewriteReadiness` trait method
   (`Ready | NotReady | Unknown`, default `Unknown`). MVs reporting
   `NotReady` are filtered out of the candidate set at LP rewrite time.

2. **Per-branch metadata that survives to the cost function** via
   `RewriteContext::candidates: Vec<CandidateMetadata>`, aligned with
   `OneOf::branches`. `CandidateMetadata::Materialized { table_ref, readiness }`
   carries the provider's raw readiness verbatim, so cost functions can
   apply their own policy for the `Unknown` case (e.g. fall back to base
   scan cost) instead of being forced to trust every candidate equally.
   `table_ref` is stored as a `TableReference` (not stringified) so
   quoted / dotted identifiers round-trip losslessly through the
   physical-time catalog resolution.

3. **Physical-time readiness refresh in `ViewExploitationPlanner::plan_extension`**
   re-consults each `Materialized` provider *after* DataFusion has invoked
   `TableProvider::scan()` on every candidate branch. Providers that opt
   into `ReadinessAnnotatedExec` (see below) get their readiness read
   straight off the plan tree — atomically captured at scan time.
   Providers that haven't opted in fall back to catalog sampling, which
   is best-effort and can be stale under concurrent snapshot swaps.
   `drop_not_ready_after_refresh` then removes any candidate that
   transitioned to `NotReady`, preserving the invariant that
   `NotReady` never reaches the cost function.

## Architecture

The three layers wire together like this. The **provider is consulted twice**
— once at LP-rewrite time (cold, `last_modified` may still be `None`) and
again at physical-planning time (after `scan()` has run, so any lazy index is
warm and readiness is definitive). `NotReady` is filtered by two gates so the
cost function only ever sees `Base | Ready | Unknown`.

```mermaid
flowchart TD
    A["SQL"] --> B["Logical planning"]
    B --> C["ViewMatcher::f_down<br/>(LP time)"]
    C -->|"provider.rewrite_readiness()<br/>#1 · cold, pre-scan"| D{"Readiness?"}
    D -->|NotReady| E["🚫 filtered — never enters OneOf"]
    D -->|Ready / Unknown| F["OneOf {<br/>branches: [Base, MV_a, MV_b, ...],<br/>candidates: [Base, Materialized{ref, readiness}, ...]<br/>}"]
    F --> G["Physical planning"]
    G -->|"TableProvider::scan()<br/>· lazy index warms here<br/>· provider wraps output in<br/>ReadinessAnnotatedExec<br/>with atomically-captured readiness"| H["ViewExploitationPlanner::plan_extension"]
    H -->|"prefer annotated readiness on the plan<br/>OR fall back to sampling<br/>provider.rewrite_readiness() #2"| I["refresh_candidate_readiness<br/>· update metadata with fresh value"]
    I --> J["drop_not_ready_after_refresh<br/>· post-scan NotReady 🚫"]
    J -->|only Base left| K["Short-circuit:<br/>return base physical plan"]
    J -->|multiple candidates| L["OneOfExec::try_new(cost_fn)"]
    L -->|"CostContext.candidates:<br/>[Base, Ready, Unknown]<br/>(NotReady impossible)"| M["Cost function"]
    M --> N["PruneCandidates picks min"]
    K --> Z["Execute"]
    N --> Z
```

> **Atomic-readiness opt-in**: Sampling `rewrite_readiness()` again after
> `scan()` has returned is racy — a concurrent snapshot swap can publish
> new state between the two calls, letting an `EmptyExec` from the old
> snapshot be labelled with readiness from the new one. Providers close
> that race by capturing readiness atomically at scan time and returning
> `Arc::new(ReadinessAnnotatedExec::new(scan_output, captured_readiness))`.
> The refresh walks each candidate's plan tree for a wrapper and reads
> its readiness verbatim; providers that haven't opted in keep the
> (racy) sampling fallback for backward compatibility.

The library ships layers 1–3 plus the atomic-readiness vehicle. The provider
(e.g. atlas's `MaterializedView<Index>`) implements `rewrite_readiness` however
fits its lifecycle model and optionally wraps its scan output in
`ReadinessAnnotatedExec`; the cost function branches on the `readiness`
value however fits its cost model. The atlas companion PR wires up both:

| Layer | Responsibility | Owned by |
|---|---|---|
| `Materialized::rewrite_readiness` | Report lifecycle state (cheap check) | Provider |
| `f_down` NotReady filter | Drop pre-scan NotReady from candidate set | This PR |
| Per-branch `CandidateMetadata` | Carry `readiness` value through to cost fn | This PR |
| `ReadinessAnnotatedExec` wrapper | Atomically propagate readiness with the scan output | Provider opt-in; wrapper defined here |
| `plan_extension` refresh + filter | Re-consult (annotated or sampled) after scan, drop post-scan NotReady | This PR |
| `deprioritize_empty_candidates` | Trust `Ready`+empty, penalise `Unknown`+empty | Cost fn (atlas side) |

## File organisation

All readiness-related types and helpers live in `src/rewrite/readiness.rs`:
`RewriteReadiness`, `CandidateMetadata`, `ReadinessAnnotatedExec`,
`readiness_from_plan`, `refresh_candidate_readiness`,
`drop_not_ready_after_refresh`, `resolve_current_readiness`. The pre-move
locations (`crate::materialized::RewriteReadiness`,
`crate::rewrite::exploitation::{CandidateMetadata, ReadinessAnnotatedExec,
readiness_from_plan}`) still resolve via `pub use` re-exports, so downstream
callers don't have to change their imports.

## Changes

**`Materialized` trait** (in `src/materialized.rs`)
* New `RewriteReadiness` enum (defined in `src/rewrite/readiness.rs`,
  re-exported here for backward compat): `Ready` / `NotReady` / `Unknown`.
* New `fn rewrite_readiness(&self) -> RewriteReadiness` with `Unknown`
  default — backward-compatible for providers that don't distinguish
  lifecycle states.

**`CandidateMetadata` + `ReadinessAnnotatedExec`** (in `src/rewrite/readiness.rs`)
* `CandidateMetadata::Materialized { table_ref: TableReference, readiness }`
  carries the provider's raw readiness verbatim. `TableReference` (not
  `String`) so quoted / dotted identifiers round-trip losslessly.
  Sorted deterministically by `TableReference` in `f_down` so alignment
  survives downstream LP rewrites via `with_exprs_and_inputs`.
* `ReadinessAnnotatedExec` transparent wrapper carrying a
  `RewriteReadiness` value alongside an `ExecutionPlan`, so providers can
  publish the readiness that corresponds to the snapshot their `scan()`
  read from.
* `readiness_from_plan` depth-first walker used by the refresh to
  extract annotated readiness from a candidate's physical input.

**`ViewMatcher::f_down`**
* Filters `NotReady` MVs before they enter the candidate set.
* Encodes `Ready` / `Unknown` values into `CandidateMetadata::Materialized`.
* Pre-sorts MV candidates so `OneOf::inputs()` becomes a no-op.
* Keeps the base branch pinned at `branches[0]`.

**`ViewExploitationPlanner::plan_extension`**
* Calls `refresh_candidate_readiness` — prefers `ReadinessAnnotatedExec`
  when a candidate's `physical_input` carries one; falls back to catalog
  sampling otherwise.
* Filters `NotReady` post-scan transitions via `drop_not_ready_after_refresh`.
* Short-circuits to the base physical plan directly when only Base remains.

## Test coverage (61 lib tests, all passing)

New in this PR (organised by concern):

* **Metadata field** — `f_down_encodes_ready_and_unknown_readiness_verbatim`,
  `candidate_metadata_partial_eq_discriminates_readiness`,
  `one_of_alignment_survives_rebuild_with_unknown_readiness`.
* **LP-time filter** — `f_down_excludes_not_ready_and_admits_ready_and_unknown`,
  `f_down_returns_original_lp_when_every_mv_is_not_ready`,
  `f_down_reflects_provider_readiness_on_each_rewrite`.
* **Physical-time refresh** — 5 tests covering post-scan Unknown → Ready,
  Unknown → NotReady when scan uncovers unpopulated, missing-provider
  fallback, Base variant preservation, and Base-at-index-0 invariant.
* **Atomic-readiness wrapper** — `refresh_prefers_annotated_readiness_over_catalog_sampling`
  (intentional disagreement between annotated Ready and sampled Unknown,
  asserts annotated wins), `refresh_falls_back_to_sampling_when_input_not_annotated`,
  `readiness_from_plan_walks_nested_children`,
  `readiness_from_plan_returns_none_when_no_annotation`,
  `readiness_annotated_exec_delegates_properties_and_children`.
* **NotReady filter** — 3 tests covering the happy path, backward-compat
  passthrough when metadata is missing, and the collapse-to-Base short-circuit.
* **End-to-end via `plan_extension`** — 2 tests driving the actual planner
  method through a `SessionContext`, covering the cold-lazy Ready promotion
  and the short-circuit-to-base scenarios.

## Affects

Downstream cost functions consuming `RewriteContext::candidates()` and MV
providers overriding `rewrite_readiness()`. The atlas repo has a companion
PR that:

* Overrides `MaterializedView<Index>::rewrite_readiness()` to report `Ready`
  when `Index::get_last_modified().is_some()` and `Unknown` otherwise.
  Never returns `NotReady` — atlas cannot cheaply distinguish cold-lazy
  from unpopulated, so `Unknown` + cost-fn fallback handles both.
* Modifies `deprioritize_empty_candidates` to skip the `+INFINITY` penalty
  when a candidate is `Materialized { readiness: Ready }` (trust the empty
  as predicate-pruned); the pre-readiness "penalize every empty" behaviour
  is retained as a fallback for `Unknown` and for older callsites that
  don't wire `CandidateMetadata` through.
* Verified end-to-end against ny2 staging: PQXX-shape query on
  `external.etfglobal.constituents_v1` picks the specialised MV, returns
  `EmptyExec` in microseconds instead of the previous 30 s base-table
  scan.
